### PR TITLE
Potential fix for code scanning alert no. 62: Information exposure through an exception

### DIFF
--- a/app/backend/api/chat.py
+++ b/app/backend/api/chat.py
@@ -352,11 +352,10 @@ async def chat_web_search(request: ChatRequestEnhanced):
     except Exception as e:
         logger.error(f"Web search endpoint error: {e}", exc_info=True)
         logger.info("Falling back to standard chat due to error")
-        error_text = str(e)
         
         # Fallback to standard chat on any error
         async def error_fallback():
-            error_msg = f"Web search error: {error_text}. Defaulting to local results.\n\n"
+            error_msg = "Web search is temporarily unavailable. Defaulting to local results.\n\n"
             yield error_msg
             
             async for chunk in _stream_chat_response(request):


### PR DESCRIPTION
Potential fix for [https://github.com/debabratamishra/litemind-ui/security/code-scanning/62](https://github.com/debabratamishra/litemind-ui/security/code-scanning/62)

The fix is to stop returning raw exception details to the client while preserving server-side observability. Keep detailed logging (`exc_info=True`) for developers, but replace the client-facing streamed error prefix with a generic, non-sensitive message.

Best single fix in `app/backend/api/chat.py`:
- In `chat_web_search`, inside the `except Exception as e` block (around lines 352–360), remove use of `str(e)` for user output.
- Keep existing `logger.error(..., exc_info=True)` unchanged.
- Replace the constructed `error_msg` with a constant generic message such as:  
  `"Web search is temporarily unavailable. Defaulting to local results.\n\n"`  
This preserves fallback behavior and user experience (still informed of fallback) without leaking internals.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
