### PR TITLE
Potential fix for code scanning alert no. 60: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -827,7 +827,7 @@ async def get_stt_status():
         return speech_service.get_status()
     except Exception as e:
         logger.error(f"Failed to get STT status: {e}")
-        return {"available": False, "error": str(e)}
+        return {"available": False, "error": "Unable to retrieve STT status"}
 
 
 # Utility functions


### PR DESCRIPTION
Potential fix for [https://github.com/debabratamishra/litemind-ui/security/code-scanning/60](https://github.com/debabratamishra/litemind-ui/security/code-scanning/60)

The safest fix is to stop returning raw exception details in API responses and replace them with a generic client-facing message, while keeping detailed context in server logs.

Best single change in `main.py`:
- In `get_stt_status()` exception block (around lines 828–830), keep logging the exception, but replace `str(e)` in the returned JSON with a constant generic message such as `"Unable to retrieve STT status"`.

This preserves functionality (the endpoint still reports `available: False` when failing) without leaking internal error information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
