### PR TITLE
Potential fix for code scanning alert no. 69: Information exposure through an exception

### DIFF
--- a/app/backend/api/health.py
+++ b/app/backend/api/health.py
@@ -41,7 +41,8 @@ async def readiness_check():
             else:
                 status_data["checks"]["rag_service"] = {"status": "ready"}
         except Exception as e:
-            status_data["checks"]["rag_service"] = {"status": "error", "error": str(e)}
+            logger.exception("RAG service readiness check failed")
+            status_data["checks"]["rag_service"] = {"status": "error", "error": "Internal error"}
             status_data["status"] = "not_ready"
         
         # Check critical directories
@@ -59,8 +60,8 @@ async def readiness_check():
             return JSONResponse(status_code=503, content=status_data)
             
     except Exception as e:
-        logger.error(f"Readiness check failed: {e}")
+        logger.exception("Readiness check failed")
         return JSONResponse(
             status_code=503, 
-            content={"status": "error", "error": str(e), "timestamp": time.time()}
+            content={"status": "error", "error": "Internal error", "timestamp": time.time()}
         )


### PR DESCRIPTION
Potential fix for [https://github.com/debabratamishra/litemind-ui/security/code-scanning/69](https://github.com/debabratamishra/litemind-ui/security/code-scanning/69)

To fix this without changing endpoint behavior, keep the readiness status structure and HTTP codes the same, but stop returning raw exception messages to clients.

Best approach in this file:
1. In the inner `except` around `rag_service`, replace `str(e)` in the response payload with a generic message (for example `"Internal error"`), and log the actual exception with stack trace via `logger.exception(...)`.
2. In the outer `except`, similarly avoid `str(e)` in JSON content; return a generic error string and log full details server-side (`logger.exception(...)`).

This preserves functional behavior:
- still reports `not_ready` / `error`,
- still returns 503 when not ready or failing,
- still gives operators detailed logs for debugging,
- but no longer exposes exception internals to API consumers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
