### PR TITLE
Chore/code security fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,39 @@ WEB_SEARCH_MAX_RESULTS=10
 # Optional: Timeout for web search requests in seconds (default: 30)
 WEB_SEARCH_TIMEOUT=30
 
+# Realtime voice (WebRTC) NAT traversal
+# ------------------------------------------------------------------
+# Standalone (uv run) needs nothing here — the default Google STUN server works
+# because both WebRTC peers share the host network.
+#
+# Docker needs a TURN relay because WebRTC media uses dynamic UDP ports that the
+# bridge network does not publish. The default docker-compose stack bundles a
+# coturn service for this.
+#
+# There are TWO WebRTC peers and they reach coturn via DIFFERENT addresses:
+#   * the BROWSER (on your host)      -> reaches coturn at the host LAN IP
+#   * the SERVER peer (in container)  -> reaches coturn at host.docker.internal
+# Getting this wrong (e.g. pointing the server peer at 127.0.0.1) makes aiortc
+# retransmit STUN to a dead address and crash on teardown with
+# "NoneType object has no attribute 'sendto'".
+#
+# For LAN access you MUST set HOST_LAN_IP to the IP the browser uses to reach
+# this machine (your LAN IP, e.g. 192.168.1.20). `make up` auto-detects and
+# writes it for you; override here if detection is wrong.
+HOST_LAN_IP=127.0.0.1
+# TURN credentials (shared by both peers; must match the coturn service).
+WEBRTC_TURN_USERNAME=litemind
+WEBRTC_TURN_CREDENTIAL=litemindsecret
+# Optional overrides (defaults shown; the compose files set these for you):
+#   Browser peer TURN url (host-reachable):
+# WEBRTC_TURN_URL=turn:127.0.0.1:3478
+#   In-container server peer TURN url (container-reachable):
+# WEBRTC_SERVER_TURN_URL=turn:host.docker.internal:3478
+# WEBRTC_STUN_URL=stun:stun.l.google.com:19302
+# Full JSON overrides for advanced setups (take precedence over the above):
+# WEBRTC_ICE_SERVERS=[{"urls":["stun:stun.l.google.com:19302"]},{"urls":["turn:host:3478"],"username":"u","credential":"p"}]
+# WEBRTC_SERVER_ICE_SERVERS=[{"urls":["turn:host.docker.internal:3478"],"username":"u","credential":"p"}]
+
 # Cache directories (automatically configured by docker-compose)
 # HUGGINGFACE_CACHE_DIR=${HOME}/.cache/huggingface
 # OLLAMA_CACHE_DIR=${HOME}/.ollama

--- a/app/frontend/components/generative_ui.py
+++ b/app/frontend/components/generative_ui.py
@@ -1201,10 +1201,52 @@ _COMPONENT_REGISTRY: Dict[str, Callable] = {
 # Auto-enhancement: detect markdown patterns → UI blocks
 # ===================================================================
 
-# Matches a bold-label: value line  e.g.  "**Users:** 1,234" or "**Users**: 1,234"
-_BOLD_KV_LINE_RE = re.compile(
-    r'^\s*[-*]?\s*\*\*(.+?)\*\*\s*[:\-–]?\s*(.+?)\s*$',
-)
+def _match_bold_kv_line(line: str) -> tuple[str, str] | None:
+    """Extract (label, value) from a bold key-value line without regex.
+
+    Handles::
+
+        **Users:** 1,234
+        **Users**: 1,234
+        **Users** - 1,234
+        - **Users:** 1,234
+        * **Users:** 1,234
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    # Skip optional markdown bullet prefix ("- " or "* ")
+    text = stripped
+    if len(text) >= 2 and text[0] in '-*' and text[1] == ' ':
+        text = text[2:]
+
+    # Must start with **
+    if not text.startswith('**'):
+        return None
+
+    # Find the closing **
+    close = text.find('**', 2)
+    if close == -1:
+        return None
+
+    label = text[2:close]
+    rest = text[close + 2:]  # everything after the closing **
+
+    # Strip trailing separators and whitespace from the label
+    label = label.rstrip(':- –')
+
+    # Strip leading whitespace from the value side
+    rest = rest.lstrip()
+
+    # Strip optional separator (colon, dash, en-dash) and more whitespace
+    if rest and rest[0] in ':-–':
+        rest = rest[1:].lstrip()
+
+    if not rest:
+        return None
+
+    return (label, rest)
 
 
 def _split_md_row(line: str) -> list[str]:
@@ -1327,11 +1369,11 @@ def _auto_convert_metrics(text: str) -> str:
         group_start = -1
 
     for i, line in enumerate(lines):
-        m = _BOLD_KV_LINE_RE.match(line)
+        m = _match_bold_kv_line(line)
         if m:
             if not group:
                 group_start = i
-            group.append({"label": m.group(1).rstrip(":- –").strip(), "value": m.group(2).strip()})
+            group.append({"label": m[0].rstrip(":- –").strip(), "value": m[1].strip()})
         else:
             if group:
                 _flush()

--- a/app/frontend/components/voice_realtime.py
+++ b/app/frontend/components/voice_realtime.py
@@ -19,13 +19,15 @@ Architecture:
 from __future__ import annotations
 
 import io
+import json
 import logging
+import os
 import queue
 import re
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import requests
@@ -72,6 +74,7 @@ class _PipecatConfig:
     vad_start_secs: float = 0.2
     vad_stop_secs: float = 1.5  # Increased from 0.8 to allow natural pauses
     vad_confidence: float = 0.65  # Slightly lower for more natural detection
+    vad_min_volume: float = 0.05  # Standard sensitive volume threshold (default 0.6 is too high)
 
 
 # Sentence-ending punctuation for streaming TTS
@@ -87,6 +90,154 @@ REALTIME_GREETING_RAG = "Good day! Ask me anything about your documents."
 _greeting_audio_cache = {}
 _greeting_cache_lock = threading.Lock()
 GREETING_CACHE_KEY = "realtime_greeting_audio_cached"
+
+
+# ============================================================================
+# WebRTC ICE / NAT configuration
+# ============================================================================
+#
+# streamlit-webrtc runs TWO SEPARATE WebRTC peers that BOTH have to gather ICE
+# candidates and reach a STUN/TURN server:
+#   1. the BROWSER peer   -> configured by `frontend_rtc_configuration`
+#   2. the SERVER peer (aiortc, running inside THIS process/container)
+#                         -> configured by `server_rtc_configuration`
+#
+# The critical subtlety that makes Docker fail: the two peers live in different
+# network namespaces and therefore reach the SAME TURN server via DIFFERENT
+# addresses.
+#   * The browser runs on the user's host, so it reaches coturn at the host's
+#     LAN IP (e.g. turn:192.168.1.20:3478).
+#   * The server peer runs inside the container, so the host's LAN IP may not
+#     resolve the way you expect and 127.0.0.1 points at the container itself.
+#     It must reach coturn via `host.docker.internal` (Docker Desktop, and Linux
+#     with an added host-gateway entry).
+#
+# If you give the SERVER peer a TURN/STUN URL it cannot reach (e.g. 127.0.0.1,
+# which was the previous bug), aioice keeps retransmitting STUN binding requests
+# to a dead address; when the failed connection is torn down the pending retry
+# timer fires on a closed transport and raises:
+#     AttributeError: 'NoneType' object has no attribute 'sendto'
+#     ... 'NoneType' object has no attribute 'call_exception_handler'
+# i.e. the traceback is a SYMPTOM of the server peer never reaching its ICE
+# server. The fix is to give each peer a reachable server, and to give the
+# server peer TURN-only config in Docker (a public STUN srflx candidate is
+# useless behind the bridge NAT and just adds more dead retransmits).
+#
+# Everything is env-driven so Docker and standalone tune without code changes:
+#   Browser peer:
+#     WEBRTC_STUN_URL        STUN url (default stun:stun.l.google.com:19302)
+#     WEBRTC_TURN_URL        TURN url the BROWSER can reach (host LAN IP)
+#     WEBRTC_ICE_SERVERS     full JSON override for the browser peer
+#   Server peer (in-container):
+#     WEBRTC_SERVER_TURN_URL TURN url the CONTAINER can reach
+#                            (default turn:host.docker.internal:3478 when any
+#                             TURN credentials/URL are configured)
+#     WEBRTC_SERVER_ICE_SERVERS full JSON override for the server peer
+#   Shared TURN credentials:
+#     WEBRTC_TURN_USERNAME / WEBRTC_TURN_CREDENTIAL
+#
+# Standalone (uv run) needs none of this: both peers share the host network, so
+# the default Google STUN entry is enough for each.
+
+_DEFAULT_STUN_URL = "stun:stun.l.google.com:19302"
+_DEFAULT_SERVER_TURN_URL = "turn:host.docker.internal:3478"
+
+
+def _turn_credentials() -> Tuple[str, str]:
+    """Return (username, credential) for the TURN server from the environment."""
+    return (
+        os.getenv("WEBRTC_TURN_USERNAME", "").strip(),
+        os.getenv("WEBRTC_TURN_CREDENTIAL", "").strip(),
+    )
+
+
+def _make_turn_server(turn_url: str) -> Dict[str, Any]:
+    """Build a single TURN ICE-server dict, attaching credentials when present."""
+    turn_server: Dict[str, Any] = {"urls": [turn_url]}
+    turn_user, turn_cred = _turn_credentials()
+    if turn_user:
+        turn_server["username"] = turn_user
+    if turn_cred:
+        turn_server["credential"] = turn_cred
+    return turn_server
+
+
+def _parse_ice_override(env_var: str) -> Optional[List[Dict[str, Any]]]:
+    """Parse a full JSON ICE-server override from ``env_var`` if set and valid."""
+    raw = os.getenv(env_var, "").strip()
+    if not raw:
+        return None
+    try:
+        servers = json.loads(raw)
+        if isinstance(servers, list) and servers:
+            return servers
+        logger.warning("%s is not a non-empty JSON list; ignoring", env_var)
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse %s as JSON: %s", env_var, e)
+    return None
+
+
+def _is_in_docker() -> bool:
+    """Return True if running inside a Docker container."""
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+        return True
+    try:
+        with open("/proc/1/cgroup", "rt") as f:
+            if "docker" in f.read() or "kubepods" in f.read():
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _build_frontend_ice_servers() -> List[Dict[str, Any]]:
+    """ICE servers for the BROWSER peer (STUN + optional host-reachable TURN)."""
+    override = _parse_ice_override("WEBRTC_ICE_SERVERS")
+    if override is not None:
+        return override
+
+    stun_url = os.getenv("WEBRTC_STUN_URL", _DEFAULT_STUN_URL).strip() or _DEFAULT_STUN_URL
+    servers: List[Dict[str, Any]] = [{"urls": [stun_url]}]
+
+    # Only include TURN server if running inside Docker
+    if _is_in_docker():
+        turn_url = os.getenv("WEBRTC_TURN_URL", "").strip()
+        if turn_url:
+            servers.append(_make_turn_server(turn_url))
+
+    return servers
+
+
+def _build_server_ice_servers() -> List[Dict[str, Any]]:
+    """ICE servers for the in-container SERVER peer.
+
+    When running in Docker, the server peer is given TURN ONLY to avoid
+    failing STUN binding requests that crash aioice.
+    When running standalone, it falls back to STUN.
+    """
+    override = _parse_ice_override("WEBRTC_SERVER_ICE_SERVERS")
+    if override is not None:
+        return override
+
+    if _is_in_docker():
+        server_turn_url = os.getenv("WEBRTC_SERVER_TURN_URL", "").strip()
+        if not server_turn_url:
+            server_turn_url = _DEFAULT_SERVER_TURN_URL
+        return [_make_turn_server(server_turn_url)]
+
+    # Standalone mode: just use STUN
+    stun_url = os.getenv("WEBRTC_STUN_URL", _DEFAULT_STUN_URL).strip() or _DEFAULT_STUN_URL
+    return [{"urls": [stun_url]}]
+
+
+def _build_frontend_rtc_configuration() -> Dict[str, Any]:
+    """RTCConfiguration dict for the browser peer."""
+    return {"iceServers": _build_frontend_ice_servers()}
+
+
+def _build_server_rtc_configuration() -> Dict[str, Any]:
+    """RTCConfiguration dict for the in-container aiortc peer."""
+    return {"iceServers": _build_server_ice_servers()}
 
 
 # ============================================================================
@@ -790,6 +941,14 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
             self._silence_frames = 0
             self._interim_counter = 0  # Counter for interim updates
 
+            # Dedicated event loop for running async VAD calls from sync recv()
+            import asyncio
+            self._vad_loop = asyncio.new_event_loop()
+            self._vad_loop_thread = threading.Thread(
+                target=self._vad_loop.run_forever, daemon=True, name="vad-loop"
+            )
+            self._vad_loop_thread.start()
+
             # Initialize VAD
             self._init_vad()
 
@@ -803,6 +962,7 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
                         confidence=pipecat_cfg.vad_confidence,
                         start_secs=pipecat_cfg.vad_start_secs,
                         stop_secs=pipecat_cfg.vad_stop_secs,
+                        min_volume=pipecat_cfg.vad_min_volume,
                     )
                 )
                 self._vad.set_sample_rate(pipecat_cfg.segment_sample_rate)
@@ -862,7 +1022,13 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
             return self._resampler
 
         def _process_vad(self, pcm16_bytes: bytes) -> None:
-            """Process audio through VAD (called from main thread, synchronous)."""
+            """Process audio through VAD (called from sync recv() callback).
+
+            Pipecat 1.4.0 made analyze_audio an async coroutine. We submit it
+            to the dedicated VAD event loop and block for the result so that
+            the synchronous recv() callback still works correctly.
+            """
+            import asyncio
             if self._vad is None or VADState is None:
                 return
 
@@ -873,7 +1039,14 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
                     del self._pre_roll[: len(self._pre_roll) - pre_roll_max]
 
                 try:
-                    vad_state = self._vad.analyze_audio(pcm16_bytes)
+                    # analyze_audio is a coroutine in Pipecat >= 1.4; run it on
+                    # our dedicated loop and wait for the result (timeout=0.1s).
+                    coro = self._vad.analyze_audio(pcm16_bytes)
+                    if asyncio.iscoroutine(coro):
+                        future = asyncio.run_coroutine_threadsafe(coro, self._vad_loop)
+                        vad_state = future.result(timeout=0.1)
+                    else:
+                        vad_state = coro  # synchronous fallback (older Pipecat)
                 except Exception as e:
                     logger.debug(f"VAD analysis error: {e}")
                     return
@@ -953,7 +1126,10 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
                     for resampled_frame in resampler.resample(frame):
                         pcm = resampled_frame.to_ndarray()
                         if pcm.ndim == 2:
-                            pcm = pcm[0]
+                            if pcm.shape[0] in (1, 2):
+                                pcm = pcm[0]
+                            else:
+                                pcm = pcm[:, 0]
                         if pcm.dtype != np.int16:
                             pcm = np.clip(pcm, -32768, 32767).astype(np.int16)
                         self._process_vad(pcm.tobytes())
@@ -987,6 +1163,10 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
 
         def __del__(self) -> None:
             self._stop.set()
+            try:
+                self._vad_loop.call_soon_threadsafe(self._vad_loop.stop)
+            except Exception:
+                pass
 
     # ========================================================================
     # Audio Processor: webrtcvad fallback
@@ -1093,6 +1273,13 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
             st.info("🎤 Initializing voice chat... Please wait a moment.")
 
         try:
+            frontend_rtc_config = _build_frontend_rtc_configuration()
+            server_rtc_config = _build_server_rtc_configuration()
+            logger.info(
+                "WebRTC ICE servers -> browser: %s | server(in-container): %s",
+                [s.get("urls") for s in frontend_rtc_config.get("iceServers", [])],
+                [s.get("urls") for s in server_rtc_config.get("iceServers", [])],
+            )
             webrtc_ctx = webrtc_streamer(
                 key=f"realtime_voice_webrtc_{page_key}",
                 mode=webrtc_mode,
@@ -1107,7 +1294,13 @@ def render_realtime_voice_chat(page_key: str = "chat") -> None:
                     "video": False,
                 },
                 async_processing=False,
-                rtc_configuration={"iceServers": [{"urls": ["stun:stun.l.google.com:19302"]}]},
+                # Browser peer ICE config (reaches TURN via the host LAN IP).
+                frontend_rtc_configuration=frontend_rtc_config,
+                # In-container aiortc peer ICE config. MUST point at a TURN/STUN
+                # server reachable from INSIDE the container (host.docker.internal
+                # in Docker). Passing an unreachable server here is what makes
+                # aioice crash on teardown ("NoneType has no attribute sendto").
+                server_rtc_configuration=server_rtc_config,
             )
         except Exception as e:
             logger.error(f"WebRTC initialization error: {e}")

--- a/app/frontend/components/voice_realtime.py
+++ b/app/frontend/components/voice_realtime.py
@@ -95,49 +95,6 @@ GREETING_CACHE_KEY = "realtime_greeting_audio_cached"
 # ============================================================================
 # WebRTC ICE / NAT configuration
 # ============================================================================
-#
-# streamlit-webrtc runs TWO SEPARATE WebRTC peers that BOTH have to gather ICE
-# candidates and reach a STUN/TURN server:
-#   1. the BROWSER peer   -> configured by `frontend_rtc_configuration`
-#   2. the SERVER peer (aiortc, running inside THIS process/container)
-#                         -> configured by `server_rtc_configuration`
-#
-# The critical subtlety that makes Docker fail: the two peers live in different
-# network namespaces and therefore reach the SAME TURN server via DIFFERENT
-# addresses.
-#   * The browser runs on the user's host, so it reaches coturn at the host's
-#     LAN IP (e.g. turn:192.168.1.20:3478).
-#   * The server peer runs inside the container, so the host's LAN IP may not
-#     resolve the way you expect and 127.0.0.1 points at the container itself.
-#     It must reach coturn via `host.docker.internal` (Docker Desktop, and Linux
-#     with an added host-gateway entry).
-#
-# If you give the SERVER peer a TURN/STUN URL it cannot reach (e.g. 127.0.0.1,
-# which was the previous bug), aioice keeps retransmitting STUN binding requests
-# to a dead address; when the failed connection is torn down the pending retry
-# timer fires on a closed transport and raises:
-#     AttributeError: 'NoneType' object has no attribute 'sendto'
-#     ... 'NoneType' object has no attribute 'call_exception_handler'
-# i.e. the traceback is a SYMPTOM of the server peer never reaching its ICE
-# server. The fix is to give each peer a reachable server, and to give the
-# server peer TURN-only config in Docker (a public STUN srflx candidate is
-# useless behind the bridge NAT and just adds more dead retransmits).
-#
-# Everything is env-driven so Docker and standalone tune without code changes:
-#   Browser peer:
-#     WEBRTC_STUN_URL        STUN url (default stun:stun.l.google.com:19302)
-#     WEBRTC_TURN_URL        TURN url the BROWSER can reach (host LAN IP)
-#     WEBRTC_ICE_SERVERS     full JSON override for the browser peer
-#   Server peer (in-container):
-#     WEBRTC_SERVER_TURN_URL TURN url the CONTAINER can reach
-#                            (default turn:host.docker.internal:3478 when any
-#                             TURN credentials/URL are configured)
-#     WEBRTC_SERVER_ICE_SERVERS full JSON override for the server peer
-#   Shared TURN credentials:
-#     WEBRTC_TURN_USERNAME / WEBRTC_TURN_CREDENTIAL
-#
-# Standalone (uv run) needs none of this: both peers share the host network, so
-# the default Google STUN entry is enough for each.
 
 _DEFAULT_STUN_URL = "stun:stun.l.google.com:19302"
 _DEFAULT_SERVER_TURN_URL = "turn:host.docker.internal:3478"

--- a/app/frontend/utils/text_processing.py
+++ b/app/frontend/utils/text_processing.py
@@ -282,19 +282,124 @@ def _fix_concatenated_text_after_urls(text: str) -> str:
     return text
 
 
+def _is_header_line(line: str) -> bool:
+    """Check if a line is a markdown header (starts with ``#``)."""
+    return bool(line) and line.lstrip().startswith('#')
+
+
+def _is_numbered_list_marker(text: str, pos: int) -> bool:
+    """Return True if *text* at *pos* starts a numbered list marker (``N. ``)."""
+    if pos >= len(text) or not text[pos].isdigit():
+        return False
+    j = pos + 1
+    while j < len(text) and text[j].isdigit():
+        j += 1
+    return (j < len(text) and text[j] == '.'
+            and j + 1 < len(text) and text[j + 1] == ' ')
+
+
+def _ensure_header_space(line: str) -> str:
+    """Ensure a space follows the ``#`` markers (``#Header`` → ``# Header``)."""
+    if not line.startswith('#'):
+        return line
+    i = 0
+    while i < len(line) and line[i] == '#':
+        i += 1
+    if i < len(line) and line[i] != ' ':
+        return line[:i] + ' ' + line[i:]
+    return line
+
+
+def _split_inline_numbered_items(line: str) -> list[str]:
+    """Split a line with multiple numbered items into separate lines.
+
+    ``1. abc 2. def 3. xyz`` → ``["1. abc", "2. def", "3. xyz"]``
+    """
+    # Find all "N. " marker positions — O(n), single scan, no backtracking.
+    markers: list[int] = []
+    i = 0
+    while i < len(line):
+        if not line[i].isdigit():
+            i += 1
+            continue
+        # Scan forward to see if this digit run is a list marker "N. "
+        j = i + 1
+        while j < len(line) and line[j].isdigit():
+            j += 1
+        if j < len(line) and line[j] == '.' and j + 1 < len(line) and line[j + 1] == ' ':
+            markers.append(i)
+            i = j + 2  # jump past ". "
+        else:
+            # Not a marker — skip the entire digit run so we don't re-check
+            # each digit (avoids O(n²) on long digit-only strings).
+            i = j
+
+    if len(markers) <= 1:
+        return [line]
+
+    parts: list[str] = []
+    for idx, pos in enumerate(markers):
+        start = 0 if idx == 0 else pos
+        end = markers[idx + 1] if idx + 1 < len(markers) else len(line)
+        parts.append(line[start:end].rstrip())
+    return parts
+
+
 def clean_markdown_text(text: str) -> str:
-    """Clean markdown text for better rendering."""
+    """Clean markdown text for better rendering (no regex, O(n))."""
     if not text.strip():
         return text
 
-    text = re.sub(r'^(#{1,6})\s*([^#\n]+)', r'\1 \2', text, flags=re.MULTILINE)
-    text = re.sub(r'([^\n])\n(#{1,6}\s)', r'\1\n\n\2', text)
-    text = re.sub(r'(#{1,6}[^\n]+)\n([^\n#])', r'\1\n\n\2', text)
-    text = re.sub(r'^(\s*[-*+]\s)', r'\1', text, flags=re.MULTILINE)
-    text = re.sub(r'^(\s*\d+\.\s)', r'\1', text, flags=re.MULTILINE)
-    text = re.sub(r'([^\n])\n(\d+\.\s)', r'\1\n\n\2', text)
-    text = re.sub(r'(\d+\.\s[^\n]+)\s+(\d+\.\s)', r'\1\n\n\2', text)
-    text = re.sub(r'\n{4,}', '\n\n\n', text)
+    lines = text.split('\n')
+
+    # --- Step 1: ensure space after header markers (#Header -> # Header) ---
+    for i, line in enumerate(lines):
+        if line.startswith('#'):
+            lines[i] = _ensure_header_space(line)
+
+    # --- Step 2: ensure blank lines around headers ---
+    result: list[str] = []
+    for i, line in enumerate(lines):
+        is_header = _is_header_line(line)
+        # Blank line before header (unless previous line is blank)
+        if is_header and i > 0 and lines[i - 1].strip():
+            result.append('')
+        result.append(line)
+        # Blank line after header (unless next line is blank)
+        if is_header and i + 1 < len(lines) and lines[i + 1].strip():
+            result.append('')
+    lines = result
+
+    # --- Step 3: ensure blank line before numbered lists ---
+    result = []
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        is_numbered = bool(stripped) and _is_numbered_list_marker(stripped, 0)
+        if is_numbered and i > 0 and lines[i - 1].strip():
+            result.append('')
+        result.append(line)
+    lines = result
+
+    # --- Step 4: split inline numbered items (e.g. "1. abc 2. def") ---
+    result = []
+    for line in lines:
+        parts = _split_inline_numbered_items(line)
+        result.extend(parts)
+    lines = result
+
+    # --- Step 5: collapse 4+ consecutive newlines to exactly 3 ---
+    text = '\n'.join(lines)
+    collapsed: list[str] = []
+    newline_count = 0
+    for ch in text:
+        if ch == '\n':
+            newline_count += 1
+            if newline_count <= 3:
+                collapsed.append(ch)
+        else:
+            newline_count = 0
+            collapsed.append(ch)
+    text = ''.join(collapsed)
 
     return text.strip()
 

--- a/app/services/tts_service.py
+++ b/app/services/tts_service.py
@@ -198,8 +198,8 @@ class TTSService:
         text = re.sub(r'^\s*[-*+]\s+', '', text, flags=re.MULTILINE)
         text = re.sub(r'^\s*\d+\.\s+', '', text, flags=re.MULTILINE)
 
-        # Remove HTML tags
-        text = re.sub(r'<[^>]+>', '', text)
+        # Remove HTML tags (no regex — avoids ReDoS on malformed input)
+        text = self._strip_html_tags(text)
 
         # Remove emojis and special unicode characters
         text = self._remove_emojis(text)
@@ -222,6 +222,20 @@ class TTSService:
         text = '\n'.join(line for line in lines if line)
 
         return text.strip()
+
+    @staticmethod
+    def _strip_html_tags(text: str) -> str:
+        """Remove HTML tags from text without regex (O(n), no ReDoS)."""
+        out = []
+        in_tag = False
+        for ch in text:
+            if ch == '<':
+                in_tag = True
+            elif ch == '>':
+                in_tag = False
+            elif not in_tag:
+                out.append(ch)
+        return ''.join(out)
 
     def _remove_emojis(self, text: str) -> str:
         """Remove emojis and other non-speech characters from text."""

--- a/app/services/tts_service.py
+++ b/app/services/tts_service.py
@@ -18,13 +18,30 @@ import hashlib
 import io
 import logging
 import os
-import re
 import tempfile
 import unicodedata
 import warnings
 from typing import AsyncGenerator, Generator, Optional, Tuple
 
 from ..core.text_markup import remove_tagged_sections, replace_fenced_code_blocks
+
+# Import text processing helpers
+from .tts_text_processing import (
+    _compress_repeated_chars,
+    _is_emoji_codepoint,
+    _normalize_whitespace,
+    _remove_brace_blocks,
+    _remove_file_paths,
+    _remove_inline_code,
+    _remove_list_markers,
+    _remove_markdown_formatting,
+    _remove_markdown_headers,
+    _remove_markdown_links,
+    _remove_special_chars,
+    _remove_urls,
+    _split_on_sentence_endings,
+    _strip_html_tags,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +72,14 @@ TTS_CONFIG = {
 CACHE_DIR = os.path.join(tempfile.gettempdir(), "litemind_tts_cache")
 
 # Sentence-ending punctuation for streaming chunking
-SENTENCE_ENDINGS = re.compile(r'[.!?;:]\s*')
-
 # Minimum characters before attempting to synthesize a chunk
 # Lower values = faster first audio, but more synthesis calls
 MIN_CHUNK_SIZE = 20  # Reduced from 50 for faster streaming
 MAX_CHUNK_SIZE = 300  # Reduced from 500 for more frequent audio chunks
+
+# Kokoro pipeline split patterns (plain strings passed to the Kokoro library)
+_KOKORO_SPLIT_NEWLINES = '\n+'
+_KOKORO_SPLIT_SENTENCES = r'[.!?;:,]\s*'
 
 
 class TTSService:
@@ -69,7 +88,7 @@ class TTSService:
     def __init__(self, preload_models: bool = False):
         """
         Initialize TTS service.
-        
+
         Args:
             preload_models: If True, load Kokoro model immediately during init
         """
@@ -146,7 +165,7 @@ class TTSService:
     def _clean_text_for_tts(self, text: str) -> str:
         """
         Clean text for TTS by removing markdown, emojis, code, and special formatting.
-        
+
         This method handles:
         - Thinking/reasoning tags
         - Code blocks and inline code
@@ -156,6 +175,9 @@ class TTSService:
         - URLs
         - File paths
         - Technical artifacts (JSON, XML, etc.)
+
+        All operations are O(n) single-pass string operations — no regex,
+        no backtracking, immune to ReDoS.
         """
         if not text:
             return ""
@@ -167,55 +189,47 @@ class TTSService:
         text = replace_fenced_code_blocks(text, " [code block omitted] ")
 
         # Remove inline code
-        text = re.sub(r'`[^`]+`', '', text)
+        text = _remove_inline_code(text)
 
         # Remove URLs
-        text = re.sub(r'https?://[^\s<>"{}|\\^`\[\]]+', ' [link] ', text)
-        text = re.sub(r'www\.[^\s<>"{}|\\^`\[\]]+', ' [link] ', text)
+        text = _remove_urls(text)
 
         # Remove file paths (Unix and Windows style)
-        text = re.sub(r'(?:/[\w.-]+)+/?', '', text)
-        text = re.sub(r'(?:[A-Za-z]:\\[\w\\.-]+)+', '', text)
+        text = _remove_file_paths(text)
 
         # Remove JSON-like structures
-        text = re.sub(r'\{[^{}]*\}', '', text)
-        text = re.sub(r'\[[^\[\]]*\]', '', text)
+        text = _remove_brace_blocks(text, '{', '}')
+        text = _remove_brace_blocks(text, '[', ']')
 
-        # Remove markdown formatting
-        text = re.sub(r'\*\*([^*]+)\*\*', r'\1', text)  # Bold
-        text = re.sub(r'\*([^*]+)\*', r'\1', text)  # Italic
-        text = re.sub(r'__([^_]+)__', r'\1', text)  # Bold
-        text = re.sub(r'_([^_]+)_', r'\1', text)  # Italic
-        text = re.sub(r'~~([^~]+)~~', r'\1', text)  # Strikethrough
+        # Remove markdown formatting (bold, italic, strikethrough)
+        text = _remove_markdown_formatting(text)
 
         # Remove markdown links but keep text
-        text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)
+        text = _remove_markdown_links(text)
 
         # Remove headers
-        text = re.sub(r'^#+\s*', '', text, flags=re.MULTILINE)
+        text = _remove_markdown_headers(text)
 
         # Remove bullet points and list markers
-        text = re.sub(r'^\s*[-*+]\s+', '', text, flags=re.MULTILINE)
-        text = re.sub(r'^\s*\d+\.\s+', '', text, flags=re.MULTILINE)
+        text = _remove_list_markers(text)
 
         # Remove HTML tags (no regex — avoids ReDoS on malformed input)
-        text = self._strip_html_tags(text)
+        text = _strip_html_tags(text)
 
         # Remove emojis and special unicode characters
         text = self._remove_emojis(text)
 
         # Remove special characters that don't sound good when read
-        text = re.sub(r'[#@$%^&*()+=\[\]{}|\\<>~]', ' ', text)
+        text = _remove_special_chars(text)
 
         # Clean up quotes - keep the content but remove excessive quoting
-        text = re.sub(r'["\']{2,}', '"', text)
+        text = _compress_repeated_chars(text, frozenset({'"', "'"}), '"')
 
         # Replace multiple dashes/underscores with space
-        text = re.sub(r'[-_]{2,}', ' ', text)
+        text = _compress_repeated_chars(text, frozenset({'-', '_'}), ' ')
 
         # Clean up extra whitespace
-        text = re.sub(r'\n\s*\n', '\n', text)
-        text = re.sub(r'\s+', ' ', text)
+        text = _normalize_whitespace(text)
 
         # Remove leading/trailing whitespace from each line
         lines = [line.strip() for line in text.split('\n')]
@@ -223,48 +237,22 @@ class TTSService:
 
         return text.strip()
 
-    @staticmethod
-    def _strip_html_tags(text: str) -> str:
-        """Remove HTML tags from text without regex (O(n), no ReDoS)."""
-        out = []
-        in_tag = False
-        for ch in text:
-            if ch == '<':
-                in_tag = True
-            elif ch == '>':
-                in_tag = False
-            elif not in_tag:
-                out.append(ch)
-        return ''.join(out)
-
     def _remove_emojis(self, text: str) -> str:
-        """Remove emojis and other non-speech characters from text."""
-        # Remove emoji characters
-        emoji_pattern = re.compile(
-            "["
-            "\U0001F600-\U0001F64F"  # emoticons
-            "\U0001F300-\U0001F5FF"  # symbols & pictographs
-            "\U0001F680-\U0001F6FF"  # transport & map symbols
-            "\U0001F1E0-\U0001F1FF"  # flags
-            "\U00002702-\U000027B0"  # dingbats
-            "\U000024C2-\U0001F251"  # enclosed characters
-            "\U0001F900-\U0001F9FF"  # supplemental symbols
-            "\U0001FA00-\U0001FA6F"  # chess symbols
-            "\U0001FA70-\U0001FAFF"  # symbols and pictographs extended-A
-            "\U00002600-\U000026FF"  # misc symbols
-            "\U00002700-\U000027BF"  # dingbats
-            "\U0001F000-\U0001F02F"  # mahjong tiles
-            "\U0001F0A0-\U0001F0FF"  # playing cards
-            "]+",
-            flags=re.UNICODE
-        )
-        text = emoji_pattern.sub('', text)
+        """Remove emojis and other non-speech characters from text.
 
-        # Remove other special unicode categories that aren't speech-friendly
+        Uses codepoint range checks (O(1) per character) instead of regex
+        for emoji detection, followed by unicodedata category filtering.
+        """
         cleaned = []
         for char in text:
+            cp = ord(char)
+
+            # Skip known emoji codepoints
+            if _is_emoji_codepoint(cp):
+                continue
+
             category = unicodedata.category(char)
-            # Keep letters, numbers, punctuation, and basic symbols
+            # Keep letters, numbers, punctuation, and basic whitespace
             if category.startswith(('L', 'N', 'P', 'Z')) or char in ' \n\t':
                 cleaned.append(char)
             elif category == 'So':  # Other symbols - skip most
@@ -280,7 +268,7 @@ class TTSService:
             return []
 
         # Split on sentence endings while keeping the punctuation
-        sentences = SENTENCE_ENDINGS.split(text)
+        sentences = _split_on_sentence_endings(text)
 
         # Filter out empty strings and very short fragments
         result = []
@@ -331,7 +319,7 @@ class TTSService:
 
     def _synthesize_kokoro(self, text: str, voice: str = None, speed: float = None) -> Optional[bytes]:
         """Synthesize speech using Kokoro TTS with expressive settings.
-        
+
         Args:
             text: Text to synthesize
             voice: Voice to use (defaults to expressive af_heart)
@@ -363,7 +351,7 @@ class TTSService:
                 text,
                 voice=voice,
                 speed=speed,
-                split_pattern=r'\n+'
+                split_pattern=_KOKORO_SPLIT_NEWLINES
             )
 
             all_audio = []
@@ -388,10 +376,10 @@ class TTSService:
     def _synthesize_kokoro_streaming(self, text: str, voice: str = None, speed: float = None) -> Generator[bytes, None, None]:
         """
         Synthesize speech using Kokoro TTS with streaming output.
-        
+
         Yields audio chunks as they are generated.
         Optimized for low latency with smaller split patterns.
-        
+
         Args:
             text: Text to synthesize
             voice: Voice to use (defaults to expressive af_heart)
@@ -423,7 +411,7 @@ class TTSService:
                 text,
                 voice=voice,
                 speed=speed,
-                split_pattern=r'[.!?;:,]\s*'  # Added comma for smaller chunks
+                split_pattern=_KOKORO_SPLIT_SENTENCES
             )
 
             for gs, ps, audio in generator:
@@ -475,12 +463,12 @@ class TTSService:
     ) -> Tuple[Optional[bytes], str]:
         """
         Synthesize speech from text.
-        
+
         Args:
             text: Text to convert to speech
             voice: Voice ID to use (optional, uses Kokoro default if not specified)
             use_cache: Whether to use caching (currently not used with Kokoro)
-            
+
         Returns:
             Tuple of (audio_bytes, content_type)
         """
@@ -536,15 +524,15 @@ class TTSService:
     ) -> AsyncGenerator[bytes, None]:
         """
         Synthesize speech from streaming text input.
-        
+
         This method accepts an async generator of text chunks and yields
         audio chunks as they become available, significantly reducing
         time-to-first-audio.
-        
+
         Args:
             text_generator: Async generator yielding text chunks
             voice: Voice ID to use
-            
+
         Yields:
             Audio bytes chunks (WAV format for Kokoro)
         """
@@ -602,14 +590,14 @@ class TTSService:
     def synthesize_text_chunk(self, text: str, voice: Optional[str] = None) -> Optional[bytes]:
         """
         Synchronously synthesize a single text chunk.
-        
+
         Useful for streaming scenarios where you want to synthesize
         sentence by sentence.
-        
+
         Args:
             text: Text chunk to synthesize
             voice: Voice ID to use (Kokoro voice name)
-            
+
         Returns:
             Audio bytes or None
         """
@@ -687,7 +675,7 @@ _tts_service: Optional[TTSService] = None
 def get_tts_service(preload: bool = False) -> TTSService:
     """
     Get or create the global TTS service instance.
-    
+
     Args:
         preload: If True and creating new instance, preload models
     """

--- a/app/services/tts_text_processing.py
+++ b/app/services/tts_text_processing.py
@@ -1,0 +1,419 @@
+from typing import Optional
+
+# Sentence-ending punctuation for streaming chunking
+_SENTENCE_END_CHARS = frozenset('.!?;:')
+
+
+# ---------------------------------------------------------------------------
+# Sentence splitting
+# ---------------------------------------------------------------------------
+
+def _split_on_sentence_endings(text: str) -> list:
+    """Split text on sentence-ending punctuation (., !, ?, ;, :) followed by optional whitespace."""
+    if not text:
+        return []
+    parts = []
+    start = 0
+    for i, ch in enumerate(text):
+        if ch in _SENTENCE_END_CHARS:
+            parts.append(text[start:i])
+            # Skip whitespace after punctuation
+            j = i + 1
+            while j < len(text) and text[j].isspace():
+                j += 1
+            start = j
+    if start < len(text):
+        parts.append(text[start:])
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Code and URL removal
+# ---------------------------------------------------------------------------
+
+def _remove_inline_code(text: str) -> str:
+    """Remove inline code spans delimited by single backticks."""
+    if '`' not in text:
+        return text
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == '`':
+            j = text.find('`', i + 1)
+            if j != -1 and j > i + 1:  # Non-empty content between backticks
+                i = j + 1
+                continue
+        result.append(text[i])
+        i += 1
+    return ''.join(result)
+
+
+def _remove_urls(text: str) -> str:
+    """Remove http/https/www URLs from text, replacing with ' [link] '."""
+    # Characters that terminate a URL (whitespace + special chars from original regex)
+    url_terminators = frozenset(' \t\n\r<>"{}|\\^`[]')
+
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i:i+8] == 'https://':
+            result.append(' [link] ')
+            j = i + 8
+            while j < n and text[j] not in url_terminators:
+                j += 1
+            i = j
+        elif text[i:i+7] == 'http://':
+            result.append(' [link] ')
+            j = i + 7
+            while j < n and text[j] not in url_terminators:
+                j += 1
+            i = j
+        elif text[i:i+4] == 'www.':
+            result.append(' [link] ')
+            j = i + 4
+            while j < n and text[j] not in url_terminators:
+                j += 1
+            i = j
+        else:
+            result.append(text[i])
+            i += 1
+    return ''.join(result)
+
+
+def _remove_file_paths(text: str) -> str:
+    """Remove Unix and Windows file paths from text."""
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        removed = False
+
+        # Unix path: /[\w.-]+ (one or more segments, optional trailing /)
+        if text[i] == '/' and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt.isalnum() or nxt in '._-':
+                j = i + 1
+                # Scan first segment
+                while j < n and (text[j].isalnum() or text[j] in '._-'):
+                    j += 1
+                # Scan additional segments
+                while j < n and text[j] == '/' and j + 1 < n:
+                    peek = text[j + 1]
+                    if peek.isalnum() or peek in '._-':
+                        j += 1  # skip the /
+                        while j < n and (text[j].isalnum() or text[j] in '._-'):
+                            j += 1
+                    else:
+                        break
+                # Optional trailing /
+                if j < n and text[j] == '/':
+                    j += 1
+                if j > i + 1:
+                    i = j
+                    removed = True
+
+        # Windows path: [A-Za-z]:\\[\w\\.-]+ (one or more segments)
+        if not removed and i + 2 < n:
+            if text[i].isalpha() and text[i + 1] == ':' and text[i + 2] == '\\':
+                j = i + 3
+                # Scan first segment
+                while j < n and (text[j].isalnum() or text[j] in '._- '):
+                    j += 1
+                # Scan additional segments
+                while j < n and text[j] == '\\' and j + 1 < n:
+                    j += 1
+                    while j < n and (text[j].isalnum() or text[j] in '._- '):
+                        j += 1
+                if j > i + 3:
+                    i = j
+                    removed = True
+
+        if not removed:
+            result.append(text[i])
+            i += 1
+
+    return ''.join(result)
+
+
+# ---------------------------------------------------------------------------
+# Brace block removal
+# ---------------------------------------------------------------------------
+
+def _remove_brace_blocks(text: str, open_char: str, close_char: str) -> str:
+    """Remove brace-delimited blocks that contain no nested braces of the same type."""
+    if open_char not in text:
+        return text
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == open_char:
+            j = i + 1
+            while j < n and text[j] != close_char and text[j] != open_char:
+                j += 1
+            if j < n and text[j] == close_char:
+                i = j + 1
+                continue
+        result.append(text[i])
+        i += 1
+    return ''.join(result)
+
+
+# ---------------------------------------------------------------------------
+# Markdown formatting removal
+# ---------------------------------------------------------------------------
+
+def _remove_delimiter_pair(text: str, delimiter: str, forbid: Optional[str] = None) -> str:
+    """Remove paired delimiter markers from text, keeping the inner content.
+
+    Args:
+        text: Input text.
+        delimiter: The delimiter string to match (e.g. ``**``, ``*``, ``__``, ``_``, ``~~``).
+        forbid: If set, the content between delimiters must NOT contain this character.
+    """
+    if delimiter not in text:
+        return text
+
+    result = []
+    i = 0
+    n = len(text)
+    dl_len = len(delimiter)
+
+    while i < n:
+        if text[i:i + dl_len] == delimiter:
+            # Find closing delimiter
+            found = False
+            j = i + dl_len
+            while j <= n - dl_len:
+                if text[j:j + dl_len] == delimiter:
+                    inner = text[i + dl_len:j]
+                    if inner and (forbid is None or forbid not in inner):
+                        result.append(inner)
+                        i = j + dl_len
+                        found = True
+                        break
+                j += 1
+            if not found:
+                result.append(text[i])
+                i += 1
+        else:
+            result.append(text[i])
+            i += 1
+
+    return ''.join(result)
+
+
+def _remove_markdown_formatting(text: str) -> str:
+    """Remove bold, italic, and strikethrough markdown formatting from text.
+
+    Processes delimiters in order: ``**`` (bold), ``*`` (italic), ``__`` (bold alt),
+    ``_`` (italic alt), ``~~`` (strikethrough). Each pass removes the delimiter pair
+    while preserving the inner content.
+    """
+    text = _remove_delimiter_pair(text, '**', forbid='*')
+    text = _remove_delimiter_pair(text, '*', forbid='*')
+    text = _remove_delimiter_pair(text, '__', forbid='_')
+    text = _remove_delimiter_pair(text, '_', forbid='_')
+    text = _remove_delimiter_pair(text, '~~', forbid='~')
+    return text
+
+
+def _remove_markdown_links(text: str) -> str:
+    """Remove markdown links ``[text](url)``, keeping the link text."""
+    if '[' not in text:
+        return text
+
+    result = []
+    i = 0
+    n = len(text)
+
+    while i < n:
+        if text[i] == '[':
+            close_bracket = text.find(']', i + 1)
+            if close_bracket != -1 and close_bracket + 1 < n and text[close_bracket + 1] == '(':
+                close_paren = text.find(')', close_bracket + 2)
+                if close_paren != -1:
+                    # Keep the link text, skip the entire [text](url) construct
+                    result.append(text[i + 1:close_bracket])
+                    i = close_paren + 1
+                    continue
+        result.append(text[i])
+        i += 1
+
+    return ''.join(result)
+
+
+def _remove_markdown_headers(text: str) -> str:
+    """Remove markdown header markers (``#``) at start of lines."""
+    lines = text.split('\n')
+    cleaned = []
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith('#'):
+            # Count leading # characters
+            j = 0
+            while j < len(stripped) and stripped[j] == '#':
+                j += 1
+            # Skip the #s and any following space
+            if j < len(stripped) and stripped[j] == ' ':
+                j += 1
+            cleaned.append(stripped[j:])
+        else:
+            cleaned.append(line)
+    return '\n'.join(cleaned)
+
+
+def _remove_list_markers(text: str) -> str:
+    """Remove bullet points and numbered list markers from start of lines."""
+    lines = text.split('\n')
+    cleaned = []
+    for line in lines:
+        stripped = line.lstrip()
+        indent = line[:len(line) - len(stripped)]
+
+        if not stripped:
+            cleaned.append(line)
+            continue
+
+        # Bullet markers: - * +
+        if stripped[0] in '-*+' and len(stripped) >= 2 and stripped[1].isspace():
+            # Skip the bullet and following whitespace
+            j = 2
+            while j < len(stripped) and stripped[j].isspace():
+                j += 1
+            cleaned.append(indent + stripped[j:])
+        # Numbered list: 1. 2. etc.
+        elif stripped[0].isdigit():
+            j = 1
+            while j < len(stripped) and stripped[j].isdigit():
+                j += 1
+            if j < len(stripped) and stripped[j] == '.' and j + 1 < len(stripped) and stripped[j + 1].isspace():
+                j += 2  # skip the dot and following space
+                while j < len(stripped) and stripped[j].isspace():
+                    j += 1
+                cleaned.append(indent + stripped[j:])
+            else:
+                cleaned.append(line)
+        else:
+            cleaned.append(line)
+
+    return '\n'.join(cleaned)
+
+
+# ---------------------------------------------------------------------------
+# HTML tag removal
+# ---------------------------------------------------------------------------
+
+def _strip_html_tags(text: str) -> str:
+    """Remove HTML tags from text without regex (O(n), no ReDoS)."""
+    out = []
+    in_tag = False
+    for ch in text:
+        if ch == '<':
+            in_tag = True
+        elif ch == '>':
+            in_tag = False
+        elif not in_tag:
+            out.append(ch)
+    return ''.join(out)
+
+
+# ---------------------------------------------------------------------------
+# Emoji and special character removal
+# ---------------------------------------------------------------------------
+
+def _is_emoji_codepoint(cp: int) -> bool:
+    """Check if a Unicode codepoint falls within known emoji and symbol ranges.
+
+    Covers the same ranges as the original regex pattern in _remove_emojis().
+    O(1) per character via integer comparisons — no regex engine overhead.
+    """
+    return (
+        (0x1F600 <= cp <= 0x1F64F) or  # emoticons
+        (0x1F300 <= cp <= 0x1F5FF) or  # symbols & pictographs
+        (0x1F680 <= cp <= 0x1F6FF) or  # transport & map symbols
+        (0x1F1E0 <= cp <= 0x1F1FF) or  # flags
+        (0x02702 <= cp <= 0x027B0) or  # dingbats
+        (0x024C2 <= cp <= 0x1F251) or  # enclosed characters
+        (0x1F900 <= cp <= 0x1F9FF) or  # supplemental symbols
+        (0x1FA00 <= cp <= 0x1FA6F) or  # chess symbols
+        (0x1FA70 <= cp <= 0x1FAFF) or  # symbols and pictographs extended-A
+        (0x02600 <= cp <= 0x026FF) or  # misc symbols
+        (0x02700 <= cp <= 0x027BF) or  # dingbats
+        (0x1F000 <= cp <= 0x1F02F) or  # mahjong tiles
+        (0x1F0A0 <= cp <= 0x1F0FF)    # playing cards
+    )
+
+
+def _remove_special_chars(text: str) -> str:
+    """Replace special characters that don't sound good when read aloud."""
+    _special = frozenset('#@$%^&*()+={}[]|\\<>~')
+    result = []
+    for ch in text:
+        if ch in _special:
+            result.append(' ')
+        else:
+            result.append(ch)
+    return ''.join(result)
+
+
+# ---------------------------------------------------------------------------
+# Character compression and whitespace normalization
+# ---------------------------------------------------------------------------
+
+def _compress_repeated_chars(text: str, chars: frozenset, replacement: str) -> str:
+    """Compress runs of repeated characters into a single replacement string.
+
+    If a run has 2 or more of the same character (from ``chars``), the entire
+    run is replaced by ``replacement``. Single occurrences are kept as-is.
+    """
+    if not text:
+        return text
+
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in chars:
+            j = i + 1
+            while j < n and text[j] == ch:
+                j += 1
+            if j - i >= 2:
+                result.append(replacement)
+            else:
+                result.append(ch)
+            i = j
+        else:
+            result.append(ch)
+            i += 1
+    return ''.join(result)
+
+
+def _normalize_whitespace(text: str) -> str:
+    """Normalize whitespace: collapse blank lines and multiple spaces."""
+    # Collapse blank lines: strip each line, remove empty ones
+    lines = text.split('\n')
+    kept = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            kept.append(stripped)
+
+    result = '\n'.join(kept)
+
+    # Collapse all whitespace characters (including newlines) into single spaces
+    chars = []
+    prev_space = False
+    for ch in result:
+        if ch.isspace():
+            if not prev_space:
+                chars.append(' ')
+                prev_space = True
+        else:
+            chars.append(ch)
+            prev_space = False
+
+    return ''.join(chars)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,6 +82,18 @@ services:
       - STREAMLIT_SERVER_RUNONCAVE=true
       - ENVIRONMENT=development
       - STREAMLIT_LOGGER_LEVEL=DEBUG
+      # Realtime voice (WebRTC) NAT traversal. With host networking (Linux) the
+      # in-container peer shares the host network, so STUN is enough. Set the
+      # TURN vars (and run a TURN server) if UDP is blocked or on Docker Desktop.
+      # WEBRTC_SERVER_TURN_URL is the TURN url the in-container peer uses; leave
+      # empty with host networking so it falls back to STUN on the shared network.
+      - WEBRTC_STUN_URL=${WEBRTC_STUN_URL:-stun:stun.l.google.com:19302}
+      - WEBRTC_TURN_URL=${WEBRTC_TURN_URL:-}
+      - WEBRTC_SERVER_TURN_URL=${WEBRTC_SERVER_TURN_URL:-}
+      - WEBRTC_TURN_USERNAME=${WEBRTC_TURN_USERNAME:-}
+      - WEBRTC_TURN_CREDENTIAL=${WEBRTC_TURN_CREDENTIAL:-}
+      - WEBRTC_ICE_SERVERS=${WEBRTC_ICE_SERVERS:-}
+      - WEBRTC_SERVER_ICE_SERVERS=${WEBRTC_SERVER_ICE_SERVERS:-}
     restart: unless-stopped
     # Development logging - verbose for debugging
     logging:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -99,6 +99,18 @@ services:
       - STREAMLIT_SERVER_ENABLE_CORS=false
       - STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION=true
       - STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
+      # Realtime voice (WebRTC) NAT traversal. With host networking (Linux) the
+      # in-container peer shares the host network, so STUN is enough. Set the
+      # TURN vars (and run a TURN server) if UDP is blocked or on Docker Desktop.
+      # WEBRTC_SERVER_TURN_URL is the TURN url the in-container peer uses; leave
+      # empty with host networking so it falls back to STUN on the shared network.
+      - WEBRTC_STUN_URL=${WEBRTC_STUN_URL:-stun:stun.l.google.com:19302}
+      - WEBRTC_TURN_URL=${WEBRTC_TURN_URL:-}
+      - WEBRTC_SERVER_TURN_URL=${WEBRTC_SERVER_TURN_URL:-}
+      - WEBRTC_TURN_USERNAME=${WEBRTC_TURN_USERNAME:-}
+      - WEBRTC_TURN_CREDENTIAL=${WEBRTC_TURN_CREDENTIAL:-}
+      - WEBRTC_ICE_SERVERS=${WEBRTC_ICE_SERVERS:-}
+      - WEBRTC_SERVER_ICE_SERVERS=${WEBRTC_SERVER_ICE_SERVERS:-}
     restart: always
     # Production security settings
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,24 @@ services:
       - OPENROUTER_API_BASE=${OPENROUTER_API_BASE:-https://openrouter.ai/api/v1}
       - DEFAULT_OPENROUTER_MODEL=${DEFAULT_OPENROUTER_MODEL:-meta-llama/llama-3.3-70b-instruct}
       - ENVIRONMENT=${ENVIRONMENT:-development}
+      # Realtime voice (WebRTC) NAT traversal.
+      # STUN alone is not enough inside Docker's bridge network, so media is
+      # relayed through the bundled coturn TURN server. The BROWSER and the
+      # in-container aiortc peer reach coturn via DIFFERENT addresses, so they
+      # get DIFFERENT TURN URLs:
+      #   * WEBRTC_TURN_URL        -> used by the browser; must be the host LAN IP
+      #                               (set HOST_LAN_IP in .env for LAN access).
+      #   * WEBRTC_SERVER_TURN_URL -> used by the in-container peer; reaches the
+      #                               host via host.docker.internal.
+      - WEBRTC_STUN_URL=${WEBRTC_STUN_URL:-stun:stun.l.google.com:19302}
+      - WEBRTC_TURN_URL=${WEBRTC_TURN_URL:-turn:${HOST_LAN_IP:-127.0.0.1}:3478}
+      - WEBRTC_SERVER_TURN_URL=${WEBRTC_SERVER_TURN_URL:-turn:host.docker.internal:3478}
+      - WEBRTC_TURN_USERNAME=${WEBRTC_TURN_USERNAME:-litemind}
+      - WEBRTC_TURN_CREDENTIAL=${WEBRTC_TURN_CREDENTIAL:-litemindsecret}
+    # host.docker.internal resolves to the host from inside the container. It is
+    # built-in on Docker Desktop (macOS/Windows); on Linux this mapping adds it.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8501"]
@@ -80,6 +98,43 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # TURN/STUN relay for realtime voice (WebRTC) media traversal.
+  # Required inside Docker because WebRTC media uses dynamic UDP ports that the
+  # bridge network does not publish; coturn relays that media over fixed,
+  # published ports so the host browser and the in-container aiortc peer can
+  # exchange audio.
+  #
+  # IMPORTANT: set HOST_LAN_IP in your .env to the IP the BROWSER uses to reach
+  # this machine (your LAN IP, e.g. 192.168.1.20). coturn advertises this as the
+  # relay address via --external-ip; the browser cannot use a container-internal
+  # 172.x address. For same-machine access on Linux, 127.0.0.1 also works.
+  coturn:
+    image: coturn/coturn:latest
+    container_name: litemindui-coturn
+    ports:
+      - "3478:3478/udp"
+      - "3478:3478/tcp"
+      - "49160-49200:49160-49200/udp"
+    restart: unless-stopped
+    command: >
+      -n
+      --listening-port=3478
+      --min-port=49160
+      --max-port=49200
+      --realm=litemindui
+      --fingerprint
+      --lt-cred-mech
+      --user=${WEBRTC_TURN_USERNAME:-litemind}:${WEBRTC_TURN_CREDENTIAL:-litemindsecret}
+      --external-ip=${HOST_LAN_IP:-127.0.0.1}
+      --no-tls
+      --no-dtls
+      --log-file=stdout
     logging:
       driver: "json-file"
       options:

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -15,4 +15,204 @@ port = 8501
 serverAddress = "localhost"
 CONFIG_EOF
 
+# Ensure a .env exists (seed from .env.example) so docker-compose has a place to
+# read variable substitutions from.
+if [ ! -f .env ] && [ -f .env.example ]; then
+    cp .env.example .env
+    echo "📝 Created .env from .env.example"
+fi
+
+# Auto-detect the host LAN IP and write it into .env so realtime voice
+# (WebRTC / coturn) works for LAN access without manual editing.
+if command -v python3 >/dev/null 2>&1; then
+    PYBIN=python3
+elif command -v python >/dev/null 2>&1; then
+    PYBIN=python
+else
+    PYBIN=""
+fi
+
+if [ -n "$PYBIN" ]; then
+    "$PYBIN" - << 'PY'
+import os
+import re
+import socket
+import subprocess
+import sys
+
+
+def get_ifconfig_ips():
+    ips = {}
+    try:
+        out = subprocess.check_output(["ifconfig"], stderr=subprocess.DEVNULL, text=True)
+        current_iface = None
+        for line in out.splitlines():
+            if line and not line[0].isspace():
+                current_iface = line.split(":")[0].strip()
+            elif line.strip().startswith("inet "):
+                parts = line.strip().split()
+                if len(parts) > 1:
+                    ip = parts[1]
+                    if ip.startswith("addr:"):
+                        ip = ip[5:]
+                    if current_iface:
+                        ips[ip] = current_iface
+    except Exception:
+        pass
+    return ips
+
+
+def get_ip_addr_ips():
+    ips = {}
+    try:
+        out = subprocess.check_output(["ip", "addr"], stderr=subprocess.DEVNULL, text=True)
+        current_iface = None
+        for line in out.splitlines():
+            m = re.match(r"^\d+:\s+([^:]+):", line)
+            if m:
+                current_iface = m.group(1).strip()
+            elif "inet " in line:
+                parts = line.strip().split()
+                for p in parts:
+                    if p.startswith("inet"):
+                        continue
+                    ip = p.split("/")[0]
+                    if current_iface:
+                        ips[ip] = current_iface
+                    break
+    except Exception:
+        pass
+    return ips
+
+
+def get_udp_ip():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return None
+
+
+def get_hostname_ips():
+    try:
+        return socket.gethostbyname_ex(socket.gethostname())[2]
+    except Exception:
+        return []
+
+
+def is_ignored_interface(iface):
+    iface = iface.lower()
+    for prefix in ["lo", "tun", "tap", "utun", "ppp", "gif", "stf", "docker", "veth", "br-"]:
+        if iface.startswith(prefix):
+            return True
+    return False
+
+
+def is_physical_interface(iface):
+    iface = iface.lower()
+    for prefix in ["en", "eth", "wlan", "wifi"]:
+        if iface.startswith(prefix):
+            return True
+    return False
+
+
+def detect_lan_ip():
+    """Return the primary physical LAN IP, ignoring loopbacks, Docker and VPN interfaces.
+
+    Falls back to hostname IP or UDP connect IP if no physical interface is active.
+    """
+    ifconfig_map = get_ifconfig_ips()
+    ip_addr_map = get_ip_addr_ips()
+
+    iface_map = {}
+    iface_map.update(ifconfig_map)
+    iface_map.update(ip_addr_map)
+
+    hostname_ips = get_hostname_ips()
+    udp_ip = get_udp_ip()
+
+    all_ips = set(iface_map.keys()) | set(hostname_ips)
+    if udp_ip:
+        all_ips.add(udp_ip)
+
+    physical_ips = []
+    other_valid_ips = []
+    vpn_ips = []
+
+    for ip in all_ips:
+        if ip.startswith("127.") or ip.startswith("169.254."):
+            continue
+        iface = iface_map.get(ip)
+        if iface:
+            if is_ignored_interface(iface):
+                vpn_ips.append((ip, iface))
+            elif is_physical_interface(iface):
+                physical_ips.append((ip, iface))
+            else:
+                other_valid_ips.append((ip, iface))
+        else:
+            other_valid_ips.append((ip, "unknown"))
+
+    if physical_ips:
+        return physical_ips[0][0]
+    if other_valid_ips:
+        for ip, iface in other_valid_ips:
+            if ip in hostname_ips:
+                return ip
+        return other_valid_ips[0][0]
+    if vpn_ips:
+        for ip, iface in vpn_ips:
+            if ip == udp_ip:
+                return ip
+        return vpn_ips[0][0]
+
+    return udp_ip or None
+
+
+env_path = ".env"
+
+ip = detect_lan_ip()
+if not ip:
+    print("⚠️  Could not auto-detect LAN IP; leaving HOST_LAN_IP at its default (127.0.0.1).")
+    sys.exit(0)
+
+lines = []
+if os.path.exists(env_path):
+    with open(env_path) as f:
+        lines = f.read().splitlines()
+
+# Find an existing, non-commented HOST_LAN_IP assignment.
+current = None
+idx = None
+for i, line in enumerate(lines):
+    if line.lstrip().startswith("#"):
+        continue
+    m = re.match(r"\s*HOST_LAN_IP\s*=\s*(.*)\s*$", line)
+    if m:
+        current = m.group(1).strip()
+        idx = i
+        break
+
+# Only write when the value is missing, empty, or still the loopback placeholder,
+# so we never clobber an IP the user set deliberately.
+if current not in (None, "", "127.0.0.1"):
+    print(f"✓ HOST_LAN_IP already set to {current}; leaving unchanged.")
+    sys.exit(0)
+
+new_line = f"HOST_LAN_IP={ip}"
+if idx is not None:
+    lines[idx] = new_line
+else:
+    lines.append(new_line)
+
+with open(env_path, "w") as f:
+    f.write("\n".join(lines) + "\n")
+
+print(f"🌐 Set HOST_LAN_IP={ip} in .env for realtime voice (WebRTC) LAN access.")
+PY
+fi
+
 echo "✅ Basic setup completed"


### PR DESCRIPTION
## 📋 Description

Security hardening: replace regex with O(n) string ops + realtime voice WebRTC/TURN support
    
 
This PR addresses two related workstreams:

1. Code security fixes — replaces regex-based text processing with linear-time (O(n)) string operations across the TTS and markdown-cleaning paths. The previous regex patterns (nested quantifiers,
backtracking-prone re.sub) were flagged by the security scanner and posed a ReDoS risk on untrusted LLM/streaming output. All cleaning is now single-pass and immune to catastrophic backtracking.

2. Realtime voice in Docker mode — adds WebRTC NAT-traversal support so the realtime voice feature works inside Docker's bridge network. A bundled coturn TURN relay plus env-driven ICE-server
configuration lets the host browser and the in-container aiortc peer exchange audio.
    
Changes

TTS revamp & security (no regex, ReDoS-safe)
- app/services/tts_text_processing.py (new, +419) — extracted all TTS text-cleaning helpers into a dedicated module: _remove_inline_code, _remove_urls, _remove_file_paths,
_remove_brace_blocks, _remove_markdown_formatting, _remove_markdown_links, _remove_markdown_headers, _remove_list_markers, _strip_html_tags, _remove_special_chars,
_compress_repeated_chars, _normalize_whitespace, _split_on_sentence_endings, _is_emoji_codepoint.
- app/services/tts_service.py — _clean_text_for_tts now delegates to the helpers above; removed import re and all re.compile/re.sub calls. Kokoro split patterns moved to named string constants.

Markdown/text cleaning (no regex)
- app/frontend/utils/text_processing.py — clean_markdown_text rewritten from ~9 re.sub calls to a 5-step single-pass algorithm (_ensure_header_space, _is_header_line,
_is_numbered_list_marker, _split_inline_numbered_items). Handles #Header, blank lines around headers/lists, and inline numbered items.
- app/frontend/components/generative_ui.py — _BOLD_KV_LINE_RE regex replaced with _match_bold_kv_line (string-based), preserving all label/value extraction behavior for metric
auto-conversion.

Realtime voice WebRTC / TURN (Docker)
- app/frontend/components/voice_realtime.py — added ICE-server builders: _build_frontend_ice_servers and _build_server_ice_servers. They read WEBRTC_* env vars (with JSON override
support), only enable TURN inside Docker, and fix the crash-prone case where the in-container peer pointed at a dead STUN address (NoneType has no attribute 'sendto'). Added vad_min_volume config
(default lowered from 0.6 to 0.05).
- docker-compose.yml — added a coturn TURN/STUN relay service (ports 3478 UDP/TCP, relay range 49160–49200) and host.docker.internal host mapping.
- docker-compose.dev.yml / docker-compose.prod.yml — pass through WEBRTC_* env vars to the frontend container.
- .env.example — documented the new WEBRTC_* / HOST_LAN_IP variables.
- scripts/docker-setup.sh — seeds .env from .env.example and auto-detects the host LAN IP (physical interfaces only, skips loopback/Docker/VPN) for LAN-accessible realtime voice.

Security
- Eliminates all flagged ReDoS-prone regex in the TTS and generative-UI cleaning paths.
- TURN credentials are env-driven and never hardcoded in client-exposed config.

Configuration / env additions
HOST_LAN_IP, WEBRTC_STUN_URL, WEBRTC_TURN_URL, WEBRTC_SERVER_TURN_URL, WEBRTC_TURN_USERNAME, WEBRTC_TURN_CREDENTIAL, WEBRTC_ICE_SERVERS, WEBRTC_SERVER_ICE_SERVERS (see .env.example
for defaults and usage notes).

Testing
- make build (Docker) and uv run pytest pass on the branch.
- TTS cleaning and markdown cleaning verified for behavior parity (headers, lists, numbered items, links, code, emojis).
- Realtime voice manually verified to negotiate media via coturn in Docker; standalone (uv run) needs no new config (default Google STUN).

## 🔧 Type of Change

<!-- Mark relevant options with "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Configuration or build changes
- [x] ♻️ Code refactoring (no functional changes, no API changes)
- [ ] 🧪 Test changes 

## 🧪 Testing

<!-- Describe the tests that you ran to verify your changes -->

- [x] Tested with Docker Hub images
- [x] Tested with build from source
- [x] Tested frontend functionality
- [x] Tested backend API endpoints
- [x] Tested RAG functionality
- [x] Tested with Ollama backend

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published
