### PR TITLE
fix: restore missing nextjs-frontend/src/lib (was gitignored)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/app/backend/api/rag.py
+++ b/app/backend/api/rag.py
@@ -13,7 +13,11 @@ from app.backend.api.security_utils import sanitize_filename, validate_file_size
 from app.backend.core.config import backend_config
 from app.backend.core.embeddings import create_embedding_function, resolve_embedding_provider
 from app.backend.models.api_models import (
+    DuplicateCheckRequest,
+    DuplicateCheckResponse,
     RAGConfigRequest,
+    RagFileInfo,
+    RagFilesResponse,
     RAGQueryRequestEnhanced,
     RAGStatusResponse,
     ResetResponse,
@@ -54,6 +58,22 @@ async def get_rag_status():
     except Exception:
         logger.exception("Failed to get RAG status")
         return RAGStatusResponse(status="error", message="Failed to retrieve RAG status")
+
+
+@router.get("/files", response_model=RagFilesResponse)
+async def list_rag_files():
+    """List the files currently uploaded to the knowledge base."""
+    try:
+        files = [
+            RagFileInfo(filename=f.name, size=f.stat().st_size)
+            for f in backend_config.upload_folder.iterdir()
+            if f.is_file()
+        ]
+        files.sort(key=lambda info: info.filename.lower())
+        return RagFilesResponse(files=files)
+    except Exception:
+        logger.exception("Failed to list RAG files")
+        return RagFilesResponse(files=[])
 
 
 @router.post("/save_config")
@@ -220,6 +240,43 @@ async def reset_rag_system():
     except Exception as e:
         logger.error(f"Reset error: {e}")
         raise HTTPException(status_code=500, detail=f"Reset failed: {str(e)}")
+
+
+@router.post("/duplicate-check", response_model=DuplicateCheckResponse)
+async def duplicate_check_rag(request: DuplicateCheckRequest):
+    """Preflight check: is a file with this name already in the knowledge base?"""
+    try:
+        safe_filename = sanitize_filename(request.filename)
+    except ValueError as e:
+        return DuplicateCheckResponse(is_duplicate=False, reason=f"Invalid filename: {e}")
+
+    dest_path = backend_config.upload_folder / safe_filename
+    if dest_path.is_file():
+        return DuplicateCheckResponse(is_duplicate=True, reason=f"'{safe_filename}' is already uploaded.")
+    return DuplicateCheckResponse(is_duplicate=False, reason="")
+
+
+@router.delete("/files/{filename}")
+async def delete_rag_file(filename: str):
+    """Delete a single uploaded knowledge-base file."""
+    try:
+        safe_filename = sanitize_filename(filename)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid filename: {e}")
+
+    dest_path = backend_config.upload_folder / safe_filename
+
+    # Guard against path traversal: ensure the resolved path stays in upload_folder.
+    dest_resolved = dest_path.resolve()
+    upload_resolved = backend_config.upload_folder.resolve()
+    if not str(dest_resolved).startswith(str(upload_resolved)):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    if not dest_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    dest_path.unlink()
+    return {"status": "deleted", "filename": safe_filename}
 
 
 @router.post("/query")

--- a/app/backend/models/api_models.py
+++ b/app/backend/models/api_models.py
@@ -121,6 +121,33 @@ class RAGStatusResponse(BaseModel):
     message: Optional[str] = None
 
 
+class RagFileInfo(BaseModel):
+    """A single uploaded knowledge-base file."""
+
+    filename: str
+    size: int
+    indexed: bool = False
+
+
+class RagFilesResponse(BaseModel):
+    """Response for listing uploaded knowledge-base files."""
+
+    files: List[RagFileInfo] = []
+
+
+class DuplicateCheckRequest(BaseModel):
+    """Body for the duplicate-check preflight before upload."""
+
+    filename: str
+
+
+class DuplicateCheckResponse(BaseModel):
+    """Result of a duplicate-check preflight."""
+
+    is_duplicate: bool
+    reason: str = ""
+
+
 class UploadResult(BaseModel):
     filename: str
     status: str

--- a/nextjs-frontend/src/lib/api.ts
+++ b/nextjs-frontend/src/lib/api.ts
@@ -1,0 +1,245 @@
+import type { ChatMessage, Model, RagFile, RagStatusResponse } from '@/lib/types';
+
+/**
+ * Frontend API client for the FastAPI backend.
+ *
+ * Streaming endpoints:
+ *   - POST /api/chat/stream    → SSE (`data: {"chunk": "..."}` frames)
+ *   - POST /api/chat/web-search → plain text
+ *   - POST /api/rag/query      → plain text (with a leading citation frame)
+ *
+ * The base URL comes from NEXT_PUBLIC_API_URL (default http://localhost:8000),
+ * matching the backend default in CLAUDE.md.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+
+// ─── Request shapes ──────────────────────────────────────────────────────────
+
+export interface ChatStreamRequest {
+  message: string;
+  model?: string;
+  backend?: string;
+  api_key?: string | null;
+  api_base?: string | null;
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  repetition_penalty?: number;
+  top_k?: number;
+  min_p?: number;
+  seed?: number | null;
+  stop?: string[] | null;
+  session_id?: string;
+  conversation_history?: ChatMessage[] | null;
+  use_web_search?: boolean;
+  serp_api_key?: string | null;
+  is_voice_mode?: boolean;
+  enable_generative_ui?: boolean;
+  stream?: boolean;
+}
+
+export interface RAGQueryRequest {
+  query: string;
+  model?: string;
+  session_id?: string;
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  repetition_penalty?: number;
+  min_p?: number;
+  seed?: number | null;
+  stop?: string[] | null;
+  /** Number of results to retrieve; mapped to the backend's `n_results`. */
+  top_k?: number;
+}
+
+// ─── Low-level streaming helpers ───────────────────────────────────────────────
+
+async function* streamSSE(response: Response): AsyncGenerator<string> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('Response body is not readable');
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let sep: number;
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const event = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+
+      const dataLine = event
+        .split('\n')
+        .find((line) => line.startsWith('data:'));
+      if (!dataLine) continue;
+
+      const payload = dataLine.slice(5).trim();
+      if (!payload) continue;
+
+      let obj: { chunk?: string; error?: string };
+      try {
+        obj = JSON.parse(payload);
+      } catch {
+        // Ignore keep-alive / malformed frames.
+        continue;
+      }
+      if (obj.error) throw new Error(obj.error);
+      if (obj.chunk !== undefined) yield obj.chunk;
+    }
+  }
+}
+
+async function* streamText(response: Response): AsyncGenerator<string> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('Response body is not readable');
+  const decoder = new TextDecoder();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    yield decoder.decode(value, { stream: true });
+  }
+}
+
+async function postJSON(path: string, body: unknown, signal?: AbortSignal): Promise<Response> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+    cache: 'no-store',
+  });
+  return res;
+}
+
+// ─── Streaming chat / web search / RAG ──────────────────────────────────────────
+
+/** Stream a chat completion. The backend returns SSE frames; yields text chunks. */
+export async function* streamChat(
+  request: ChatStreamRequest,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
+  const res = await postJSON('/api/chat/stream', request, signal);
+  if (!res.ok) throw new Error(await errorText(res));
+  yield* streamSSE(res);
+}
+
+/** Stream a web-search chat completion. The backend returns plain text. */
+export async function* streamWebSearch(
+  request: ChatStreamRequest,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
+  const res = await postJSON('/api/chat/web-search', request, signal);
+  if (!res.ok) throw new Error(await errorText(res));
+  yield* streamText(res);
+}
+
+/** Stream a RAG query. The backend returns plain text (with a citation frame). */
+export async function* streamRagQuery(
+  request: RAGQueryRequest,
+  signal?: AbortSignal,
+): AsyncGenerator<string> {
+  const body = {
+    query: request.query,
+    model: request.model,
+    session_id: request.session_id,
+    temperature: request.temperature,
+    max_tokens: request.max_tokens,
+    top_p: request.top_p,
+    frequency_penalty: request.frequency_penalty,
+    repetition_penalty: request.repetition_penalty,
+    min_p: request.min_p,
+    seed: request.seed,
+    stop: request.stop,
+    n_results: request.top_k,
+  };
+  const res = await postJSON('/api/rag/query', body, signal);
+  if (!res.ok) throw new Error(await errorText(res));
+  yield* streamText(res);
+}
+
+// ─── REST endpoints ─────────────────────────────────────────────────────────────
+
+export async function getRagFiles(): Promise<{ files: RagFile[] }> {
+  const res = await fetch(`${API_BASE}/api/rag/files`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as { files: RagFile[] };
+}
+
+export async function getRagStatus(): Promise<RagStatusResponse> {
+  const res = await fetch(`${API_BASE}/api/rag/status`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as RagStatusResponse;
+}
+
+export async function deleteRagFile(filename: string): Promise<void> {
+  const res = await fetch(
+    `${API_BASE}/api/rag/files/${encodeURIComponent(filename)}`,
+    { method: 'DELETE', cache: 'no-store' },
+  );
+  if (!res.ok) throw new Error(await errorText(res));
+}
+
+export async function resetRag(): Promise<{ status: string; message: string; files_removed: number }> {
+  const res = await fetch(`${API_BASE}/api/rag/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as { status: string; message: string; files_removed: number };
+}
+
+export async function getEnhancedModels(): Promise<{
+  local_models: Model[];
+  cloud_models: Model[];
+}> {
+  const res = await fetch(`${API_BASE}/models/enhanced`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as { local_models: Model[]; cloud_models: Model[] };
+}
+
+export async function checkSerpStatus(apiKey: string | null): Promise<{ status: string; message: string }> {
+  const res = await postJSON('/api/chat/serp-status', { serp_api_key: apiKey ?? null });
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as { status: string; message: string };
+}
+
+export async function checkRagDuplicate(body: { filename: string }): Promise<{ is_duplicate: boolean; reason?: string }> {
+  const res = await postJSON('/api/rag/duplicate-check', body);
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as { is_duplicate: boolean; reason?: string };
+}
+
+export async function uploadRagFile(file: File): Promise<unknown> {
+  const form = new FormData();
+  form.append('files', file);
+  form.append('chunk_size', '500');
+
+  const res = await fetch(`${API_BASE}/api/rag/upload`, {
+    method: 'POST',
+    body: form,
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(await errorText(res));
+  return (await res.json()) as unknown;
+}
+
+// ─── Error extraction ───────────────────────────────────────────────────────────
+
+async function errorText(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (typeof data?.detail === 'string') return data.detail;
+    if (typeof data?.error === 'string') return data.error;
+    if (typeof data?.message === 'string') return data.message;
+  } catch {
+    /* fall through to status text */
+  }
+  return `${res.status} ${res.statusText}`;
+}

--- a/nextjs-frontend/src/lib/backend-proxy.ts
+++ b/nextjs-frontend/src/lib/backend-proxy.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Server-side streaming proxy used by the Next.js route handlers. It forwards a
+ * POST (with its JSON body) to the backend and pipes the upstream response body
+ * straight back to the client, preserving the streaming semantics.
+ */
+
+const BACKEND_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? process.env.BACKEND_URL ?? 'http://localhost:8000';
+
+export interface ProxyOptions {
+  /** Content-Type to advertise on the proxied response. Defaults to the
+   *  upstream's own content type, falling back to application/json. */
+  defaultContentType?: string;
+}
+
+export async function proxyStreamingPost(
+  req: NextRequest,
+  backendPath: string,
+  opts: ProxyOptions = {},
+): Promise<Response> {
+  const target = `${BACKEND_BASE}${backendPath}`;
+  const body = await req.text();
+  const contentType = req.headers.get('content-type') ?? 'application/json';
+
+  const upstream = await fetch(target, {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body,
+    cache: 'no-store',
+  });
+
+  const responseContentType =
+    opts.defaultContentType ?? upstream.headers.get('content-type') ?? 'application/json';
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      'content-type': responseContentType,
+      'cache-control': 'no-store',
+    },
+  });
+}

--- a/nextjs-frontend/src/lib/generative-ui.ts
+++ b/nextjs-frontend/src/lib/generative-ui.ts
@@ -1,0 +1,78 @@
+/**
+ * Parse an LLM response that may embed Generative-UI fenced blocks.
+ *
+ * When Generative UI is enabled, the model emits blocks like:
+ *
+ *     ```ui:component_name
+ *     { ...json payload... }
+ *     ```
+ *
+ * or, for HTML apps:
+ *
+ *     ```ui:webapp
+ *     <div>...</div>
+ *     ```
+ *
+ * `parseGenerativeUI` splits the response into ordered segments: plain `text`
+ * segments (rendered as markdown) and `ui` segments (rendered as rich
+ * components). JSON payloads are parsed into `data`; HTML payloads are kept
+ * verbatim in `content`.
+ */
+
+export type GenerativeUISegment =
+  | { type: 'text'; content: string }
+  | { type: 'ui'; component: string; content: string; data?: unknown };
+
+// Components whose payload is raw HTML rather than JSON.
+const HTML_COMPONENTS = new Set(['html', 'webapp', 'iframe_app']);
+
+const FENCE_RE = /```([^\n]*)\n([\s\S]*?)```/g;
+
+export function parseGenerativeUI(content: string): GenerativeUISegment[] {
+  const segments: GenerativeUISegment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  FENCE_RE.lastIndex = 0;
+  while ((match = FENCE_RE.exec(content)) !== null) {
+    const lang = match[1].trim();
+    const body = match[2];
+
+    const before = content.slice(lastIndex, match.index);
+    if (before.trim().length > 0) {
+      segments.push({ type: 'text', content: before });
+    }
+
+    if (lang.startsWith('ui:')) {
+      const component = lang.slice('ui:'.length).trim();
+      if (HTML_COMPONENTS.has(component)) {
+        segments.push({ type: 'ui', component, content: body });
+      } else {
+        let data: unknown;
+        try {
+          data = JSON.parse(body);
+        } catch {
+          data = undefined;
+        }
+        if (data === undefined) {
+          // Unparseable UI block — render the original fenced text.
+          segments.push({ type: 'text', content: match[0] });
+        } else {
+          segments.push({ type: 'ui', component, content: body, data });
+        }
+      }
+    } else {
+      // Ordinary code block — keep as text so markdown renders it.
+      segments.push({ type: 'text', content: match[0] });
+    }
+
+    lastIndex = FENCE_RE.lastIndex;
+  }
+
+  const after = content.slice(lastIndex);
+  if (after.trim().length > 0) {
+    segments.push({ type: 'text', content: after });
+  }
+
+  return segments;
+}

--- a/nextjs-frontend/src/lib/store.ts
+++ b/nextjs-frontend/src/lib/store.ts
@@ -1,0 +1,167 @@
+'use client';
+
+import { create } from 'zustand';
+import type { AppSettings, ConversationMode, RagFile } from '@/lib/types';
+
+/**
+ * Global client store (Zustand). Holds conversations, the active conversation
+ * id, user settings, and the cached knowledge-base file list.
+ */
+
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant' | string;
+  content: string;
+  isStreaming?: boolean;
+}
+
+export interface Conversation {
+  id: string;
+  mode: ConversationMode;
+  title: string;
+  messages: Message[];
+  webSearch: boolean;
+  updatedAt: string;
+}
+
+interface AppState {
+  conversations: Conversation[];
+  activeId: string | null;
+  settings: AppSettings;
+  ragFiles: RagFile[];
+
+  addMessage: (
+    convId: string,
+    message: { role: string; content: string; isStreaming?: boolean },
+  ) => void;
+  updateLastMessage: (convId: string, content: string, isStreaming: boolean) => void;
+  setWebSearch: (convId: string, value: boolean) => void;
+  clearConversation: (convId: string) => void;
+  createConversation: (mode: ConversationMode) => string;
+  selectConversation: (id: string) => void;
+  deleteConversation: (id: string) => void;
+  setSettings: (partial: Partial<AppSettings>) => void;
+  setRagFiles: (files: RagFile[]) => void;
+}
+
+function uid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function newSessionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `session-${Date.now().toString(36)}`;
+}
+
+const DEFAULT_SETTINGS: AppSettings = {
+  backend: 'ollama',
+  model: '',
+  apiKey: null,
+  apiBase: null,
+  ollamaUrl: null,
+  serpApiKey: null,
+  sessionId: newSessionId(),
+  temperature: 0.7,
+  maxTokens: 2048,
+  topP: 0.9,
+  topK: 40,
+  minP: 0.0,
+  frequencyPenalty: 0,
+  repetitionPenalty: 1.0,
+  seed: null,
+  stopSequences: '',
+  voiceMode: false,
+  enableGenerativeUI: false,
+  genUIDisplayMode: 'rendered',
+};
+
+function patchConversation(
+  state: AppState,
+  convId: string,
+  updater: (conv: Conversation) => Conversation,
+): Partial<AppState> {
+  return {
+    conversations: state.conversations.map((c) =>
+      c.id === convId ? { ...updater(c), updatedAt: new Date().toISOString() } : c,
+    ),
+  };
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  conversations: [],
+  activeId: null,
+  settings: DEFAULT_SETTINGS,
+  ragFiles: [],
+
+  addMessage: (convId, message) =>
+    set((state) =>
+      patchConversation(state, convId, (conv) => ({
+        ...conv,
+        messages: [
+          ...conv.messages,
+          { id: uid(), role: message.role, content: message.content, isStreaming: message.isStreaming },
+        ],
+      })),
+    ),
+
+  updateLastMessage: (convId, content, isStreaming) =>
+    set((state) =>
+      patchConversation(state, convId, (conv) => {
+        if (conv.messages.length === 0) return conv;
+        const messages = conv.messages.slice();
+        const last = messages[messages.length - 1];
+        messages[messages.length - 1] = { ...last, content, isStreaming };
+        return { ...conv, messages };
+      }),
+    ),
+
+  setWebSearch: (convId, value) =>
+    set((state) => patchConversation(state, convId, (conv) => ({ ...conv, webSearch: value }))),
+
+  clearConversation: (convId) =>
+    set((state) => patchConversation(state, convId, (conv) => ({ ...conv, messages: [] }))),
+
+  createConversation: (mode) => {
+    const id = uid();
+    const conv: Conversation = {
+      id,
+      mode,
+      title: mode === 'rag' ? 'New Knowledge Base' : 'New Chat',
+      messages: [],
+      webSearch: false,
+      updatedAt: new Date().toISOString(),
+    };
+    set((state) => ({
+      conversations: [conv, ...state.conversations],
+      activeId: id,
+    }));
+    return id;
+  },
+
+  selectConversation: (id) => set({ activeId: id }),
+
+  deleteConversation: (id) =>
+    set((state) => {
+      const conversations = state.conversations.filter((c) => c.id !== id);
+      const activeId = state.activeId === id ? (conversations[0]?.id ?? null) : state.activeId;
+      return { conversations, activeId };
+    }),
+
+  setSettings: (partial) => set((state) => ({ settings: { ...state.settings, ...partial } })),
+
+  setRagFiles: (files) => set({ ragFiles: files }),
+}));
+
+// ─── Selectors ─────────────────────────────────────────────────────────────────
+
+export const selectActiveConversation = (state: AppState): Conversation | undefined =>
+  state.conversations.find((c) => c.id === state.activeId);
+
+export const selectActiveId = (state: AppState): string | null => state.activeId;
+
+export const selectSettings = (state: AppState): AppSettings => state.settings;

--- a/nextjs-frontend/src/lib/types.ts
+++ b/nextjs-frontend/src/lib/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared frontend types.
+ *
+ * These describe the shapes the UI works with. Backend response models live in
+ * `app/backend/models/api_models.py`; the field names here mirror those models
+ * so the API layer can pass responses through with minimal mapping.
+ */
+
+export type BackendType = 'ollama' | 'openrouter' | 'nvidia_nim';
+
+export type ConversationMode = 'chat' | 'rag';
+
+/** A single message as sent to the backend (no client-only fields). */
+export interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+/** A message inside a conversation (client side), with an id and stream flag. */
+export interface UIMessage {
+  id?: string;
+  role: 'user' | 'assistant' | string;
+  content: string;
+  isStreaming?: boolean;
+}
+
+/** A single model entry returned by the enhanced models endpoint. */
+export interface Model {
+  name: string;
+  is_local: boolean;
+  parameter_size?: string;
+  quantization?: string;
+  family?: string;
+  description?: string;
+}
+
+/** A knowledge-base file as listed by the backend. */
+export interface RagFile {
+  filename: string;
+  size?: number;
+  indexed?: boolean;
+}
+
+/** Response from GET /api/rag/status. */
+export interface RagStatusResponse {
+  status: string;
+  uploaded_files?: number;
+  indexed_chunks?: number;
+  bm25_corpus_size?: number;
+  message?: string;
+}
+
+/** A user-configurable generation / connection setting. */
+export interface AppSettings {
+  backend: BackendType;
+  model: string;
+  apiKey: string | null;
+  apiBase: string | null;
+  ollamaUrl: string | null;
+  serpApiKey: string | null;
+  sessionId: string;
+  temperature: number;
+  maxTokens: number;
+  topP: number;
+  topK: number;
+  minP: number;
+  frequencyPenalty: number;
+  repetitionPenalty: number;
+  seed: number | null;
+  stopSequences: string;
+  voiceMode: boolean;
+  enableGenerativeUI: boolean;
+  genUIDisplayMode: 'rendered' | 'code';
+}

--- a/nextjs-frontend/src/lib/utils.ts
+++ b/nextjs-frontend/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Merge Tailwind class names, resolving conflicts (later classes win).
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/nextjs-frontend/src/lib/web-search-citations.ts
+++ b/nextjs-frontend/src/lib/web-search-citations.ts
@@ -1,0 +1,159 @@
+/**
+ * RAG answer + citation parsing helpers.
+ *
+ * The RAG backend prepends a single SSE-style frame to its plain-text answer:
+ *
+ *     data: {"citations": {"1": {"id": ..., "content": ..., "score": ...,
+ *                              "retrieval_method": ..., "metadata": {...}}, ...}}
+ *
+ *     <markdown answer with [1], [2] inline citation markers>
+ *
+ * `parseRagContent` strips that frame and returns the answer prose plus a list
+ * of `Citation` objects. The answer is then passed through
+ * `normalizeAnswerWhitespace` and `convertCitationMarkers` so the
+ * `MarkdownRenderer` turns `[n]` markers into clickable `#cite-n` chips.
+ */
+
+export interface Citation {
+  index: number;
+  title: string;
+  url?: string;
+  domain?: string;
+  snippet?: string;
+}
+
+export interface ParsedRagContent {
+  answer: string;
+  sources: Citation[];
+}
+
+interface RawCitationRecord {
+  id?: string;
+  content?: string;
+  score?: number;
+  retrieval_method?: string;
+  metadata?: Record<string, unknown>;
+}
+
+const CITATION_FRAME_RE = /^data:\s*(\{[\s\S]*?\})\n\n/;
+
+function deriveDomain(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseRagContent(raw: string): ParsedRagContent {
+  const match = CITATION_FRAME_RE.exec(raw);
+  if (!match) {
+    return { answer: raw, sources: [] };
+  }
+
+  let parsed: { citations?: Record<string, RawCitationRecord> } = {};
+  try {
+    parsed = JSON.parse(match[1]) as { citations?: Record<string, RawCitationRecord> };
+  } catch {
+    // Malformed frame — surface the raw text rather than throwing.
+    return { answer: raw, sources: [] };
+  }
+
+  const citations = parsed.citations ?? {};
+  const sources: Citation[] = Object.entries(citations)
+    .map(([idx, rec]) => {
+      const r = rec as RawCitationRecord;
+      const meta = (r.metadata ?? {}) as Record<string, unknown>;
+      const title =
+        (typeof meta.filename === 'string' && meta.filename) ||
+        (typeof meta.source === 'string' && meta.source) ||
+        (typeof meta.title === 'string' && meta.title) ||
+        r.id ||
+        `Source ${idx}`;
+      const url = (typeof meta.url === 'string' && meta.url) || (typeof r.id === 'string' ? r.id : undefined);
+      return {
+        index: Number(idx),
+        title: String(title),
+        url: url ? String(url) : undefined,
+        domain: deriveDomain(url ? String(url) : undefined),
+        snippet: typeof r.content === 'string' ? r.content : undefined,
+      };
+    })
+    .sort((a, b) => a.index - b.index);
+
+  const answer = raw.slice(match[0].length);
+  return { answer, sources };
+}
+
+/**
+ * Convert bare `[n]` markers into markdown links (`[n](#cite-n)`) so the
+ * MarkdownRenderer renders them as clickable citation chips. Already-linked
+ * markers (`[n](...)`) are left untouched.
+ */
+export function convertCitationMarkers(text: string): string {
+  return text.replace(/\[(\d+)\](?!\()/g, '[$1](#cite-$1)');
+}
+
+/** Collapse excessive blank lines / trailing whitespace for cleaner rendering. */
+export function normalizeAnswerWhitespace(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * Parse a web-search answer that ends with a `Sources:` block, e.g.
+ *
+ *     <answer prose>
+ *
+ *     Sources:
+ *     [1] **Title** (domain) - [Link](url)
+ *         *snippet*
+ *
+ * Returns the answer prose (without the Sources block) and the extracted
+ * citations. If no Sources block is present, returns the original text with an
+ * empty source list.
+ */
+export function parseWebSearchContent(raw: string): { answer: string; sources: Citation[] } {
+  const sourcesMatch = /\n[ \t]*Sources:[ \t]*\n([\s\S]*)$/i.exec(raw);
+  if (!sourcesMatch) {
+    return { answer: raw, sources: [] };
+  }
+
+  const answer = raw.slice(0, sourcesMatch.index).replace(/\s+$/, '');
+  const block = sourcesMatch[1];
+  return { answer, sources: parseWebSearchSources(block) };
+}
+
+const SOURCE_LINE_RE = /^\[(\d+)\]\s+\*\*(.+?)\*\*\s*\((.+?)\)\s*-\s*\[Link\]\((.+?)\)/;
+const SNIPPET_RE = /^[ \t]*\*(.+?)\*[ \t]*$/;
+
+function parseWebSearchSources(block: string): Citation[] {
+  const sources: Citation[] = [];
+  let current: Citation | null = null;
+
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.trim();
+    const m = SOURCE_LINE_RE.exec(line);
+    if (m) {
+      if (current) sources.push(current);
+      current = {
+        index: Number(m[1]),
+        title: m[2].trim(),
+        domain: m[3].trim(),
+        url: m[4].trim(),
+      };
+    } else if (current) {
+      const snippet = SNIPPET_RE.exec(line);
+      if (snippet) {
+        current.snippet = snippet[1].trim();
+      }
+    }
+  }
+  if (current) sources.push(current);
+
+  return sources;
+}


### PR DESCRIPTION
## Summary
The GitHub Actions Docker build (`npm run build`) was failing with 43 "Module not found: Can't resolve '@/lib/...'" errors.

Root cause: the entire `nextjs-frontend/src/lib/` module directory was **never committed**. `.gitignore` contained a bare `lib/` rule (line 21) that matches `nextjs-frontend/src/lib/` at any depth, silently dropping the folder from every commit.

## Changes
- **`.gitignore`**: removed the `lib/` rule. `nextjs-frontend/src/lib/` is the only `lib/` directory in the repo, so nothing else is affected.
- **Reconstructed the seven `@/lib` modules** the app imports, matching the backend contract read from the server code:
  - `utils.ts` — `cn`
  - `types.ts` — shared types
  - `store.ts` — Zustand store + selectors
  - `api.ts` — streaming (SSE for `/api/chat/stream`, plain text for web-search/rag) + REST helpers
  - `web-search-citations.ts` — `parseRagContent`, `parseWebSearchContent`, `convertCitationMarkers`, `normalizeAnswerWhitespace`
  - `backend-proxy.ts` — `proxyStreamingPost`
  - `generative-ui.ts` — `parseGenerativeUI`
- **Backend endpoints the UI expected but were missing** (added to `app/backend/api/rag.py` so the Knowledge Base panel works, not just compiles):
  - `GET /api/rag/files` ← `getRagFiles`
  - `POST /api/rag/duplicate-check` ← `checkRagDuplicate`
  - `DELETE /api/rag/files/{filename}` ← `deleteRagFile` (with path-traversal guard)

## Verification
- `npm run build` — compiled + type-checked, all routes generated
- `npm run lint` — 0 problems
- `uv run ruff check` + `python -m py_compile` on changed backend files — clean

Note: the local `ty` errors for `fastapi`/`pydantic` are an environment issue (venv not resolved by ty locally) and are unrelated to these changes.