### PR TITLE
Polish site copy, fix dev tree, add enterprise CTA and dark mode

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -3,7 +3,7 @@
 title: LiteMindUI
 description: >-
   LiteMindUI is a private, local-first AI workspace for chat, document Q&A,
-  web search, and realtime voice — your data stays with you.
+  web search, and realtime voice. Your data stays with you.
 url: "https://debabratamishra.github.io"
 baseurl: "/litemind-ui"
 markdown: kramdown

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -7,6 +7,17 @@
   <meta name="description" content="{{ page.description | default: site.description }}">
   <link rel="icon" href="{{ site.baseurl }}/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/style.css">
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('lm-theme');
+        if (!t) {
+          t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        document.documentElement.setAttribute('data-theme', t);
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body>
 
@@ -20,6 +31,11 @@
         <a href="{{ site.baseurl }}/" {% if page.url == site.baseurl or page.url == "/" %}class="active"{% endif %}>Home</a>
         <a href="{{ site.baseurl }}/developer/" {% if page.url contains "/developer" %}class="active"{% endif %}>Developer</a>
         <a class="github" href="https://github.com/debabratamishra/litemind-ui" target="_blank" rel="noopener">GitHub ↗</a>
+        <button id="theme-toggle" class="theme-toggle" type="button"
+                aria-label="Switch between light and dark theme" aria-pressed="false"
+                title="Switch theme">
+          <span class="t-icon" aria-hidden="true">🌙</span>
+        </button>
       </nav>
     </div>
   </header>
@@ -34,7 +50,7 @@
         <div class="brand"><span class="logo">L</span><span>LiteMindUI</span></div>
         <p style="max-width:320px;color:#94a3b8;font-size:.92rem;margin:12px 0 0;">
           A private, local-first AI workspace. Chat, ask your documents,
-          search the web, and talk out loud — your data stays with you.
+          search the web, and talk out loud, with your data staying with you.
         </p>
       </div>
       <div class="footer-cols">
@@ -57,6 +73,27 @@
       <span>Built with Jekyll &amp; GitHub Pages.</span>
     </div>
   </footer>
+
+  <script>
+    (function () {
+      var btn = document.getElementById('theme-toggle');
+      if (!btn) return;
+      var root = document.documentElement;
+      function sync() {
+        var icon = btn.querySelector('.t-icon');
+        var dark = root.getAttribute('data-theme') === 'dark';
+        icon.textContent = dark ? '☀️' : '🌙';
+        btn.setAttribute('aria-pressed', String(dark));
+      }
+      sync();
+      btn.addEventListener('click', function () {
+        var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        root.setAttribute('data-theme', next);
+        try { localStorage.setItem('lm-theme', next); } catch (e) {}
+        sync();
+      });
+    })();
+  </script>
 
 </body>
 </html>

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -24,6 +24,24 @@
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
     "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --nav-bg: rgba(255, 255, 255, .85);
+}
+
+/* ---------- Dark theme ---------- */
+[data-theme="dark"] {
+  --bg: #0b1020;
+  --bg-soft: #0f172a;
+  --bg-tint: #1e293b;
+  --ink: #e6e9f0;
+  --ink-soft: #c3cad6;
+  --muted: #94a3b8;
+  --line: #243049;
+  --nav-bg: rgba(11, 16, 32, .85);
+  --indigo: #818cf8;
+  --indigo-600: #6366f1;
+  --indigo-700: #a5b4fc;
+  --teal: #2dd4bf;
+  --teal-600: #5eead4;
 }
 
 * { box-sizing: border-box; }
@@ -57,7 +75,7 @@ img { max-width: 100%; height: auto; }
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(255, 255, 255, .85);
+  background: var(--nav-bg);
   backdrop-filter: saturate(180%) blur(10px);
   border-bottom: 1px solid var(--line);
 }
@@ -104,6 +122,28 @@ img { max-width: 100%; height: auto; }
   border: 1px solid var(--line);
 }
 .nav-links a.github:hover { background: var(--bg-soft); }
+
+.theme-toggle {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  margin-left: 4px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--bg-soft);
+  color: var(--ink-soft);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background .2s ease, border-color .2s ease;
+}
+.theme-toggle:hover { background: var(--bg-tint); }
+.theme-toggle:focus-visible {
+  outline: 3px solid var(--teal);
+  outline-offset: 2px;
+}
 
 /* ---------- Hero ---------- */
 .hero {
@@ -170,6 +210,13 @@ img { max-width: 100%; height: auto; }
   border: 1.5px solid var(--indigo);
 }
 .btn-outline:hover { background: var(--bg-tint); }
+.btn-solid {
+  background: var(--indigo);
+  color: #fff;
+  border: 1px solid var(--indigo);
+}
+.btn-solid:hover { background: var(--indigo-600); text-decoration: none; }
+[data-theme="dark"] .btn-solid { color: #0b1020; }
 
 /* ---------- Sections ---------- */
 section.block { padding: 64px 0; }
@@ -258,6 +305,11 @@ section.block.soft { background: var(--bg-soft); }
   margin: 24px 0;
 }
 .callout strong { color: var(--teal-600); }
+[data-theme="dark"] .callout { background: #06281f; border-left-color: #14b8a6; }
+
+/* ---------- Enterprise CTA ---------- */
+.ent-cta { margin-top: 36px; }
+.ent-cta p { max-width: 640px; margin: 0 auto 18px; color: var(--ink-soft); }
 
 /* ---------- Tables ---------- */
 .table-wrap { overflow-x: auto; margin: 18px 0; }
@@ -323,6 +375,7 @@ pre code {
   font-size: .85rem;
   line-height: 1.7;
   overflow-x: auto;
+  white-space: pre;
 }
 .tree .c { color: #94a3b8; }
 .tree .k { color: #7dd3fc; }

--- a/site/developer.md
+++ b/site/developer.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Developer guide — LiteMindUI
+title: "Developer guide: LiteMindUI"
 permalink: /developer/
 description: >-
   The technical backbone of LiteMindUI: architecture, processes and ports,
@@ -15,7 +15,7 @@ description: >-
       LiteMindUI is a <strong>local-first AI workspace</strong> supporting chat,
       retrieval-augmented generation (RAG), web search, and realtime voice. It is
       composed of a FastAPI backend and a Next.js frontend that talk to each other
-      exclusively over HTTP — they share no code imports.
+      exclusively over HTTP. They share no code imports.
     </p>
 
     <div class="table-wrap">
@@ -40,22 +40,24 @@ description: >-
     <h2>Directory layout</h2>
     <p>The backend lives in <code>app/</code>; the UI in <code>nextjs-frontend/src/</code>.</p>
     <div class="tree">
-<span class="c">app/</span>
-  <span class="k">backend/</span>
-    api/          <span class="c"># routes: chat.py, rag.py, models.py, health.py, voice.py (WebRTC SDP)</span>
-    core/         <span class="c"># backend config, embedding helpers, DEFAULT_RAG_CONFIG</span>
-    models/       <span class="c"># Pydantic request/response models</span>
-  <span class="k">core/</span>           <span class="c"># shared utils: env detection, RAG formats, text markup</span>
-  <span class="k">services/</span>       <span class="c"># business logic: llm_gateway, rag_service, voice_pipeline, …</span>
-  <span class="k">ingestion/</span>     <span class="c"># file_ingest, document processors, OCR extractors</span>
-  <span class="k">skills/</span>         <span class="c"># pluggable chat &amp; RAG skill routing</span>
+<span class="k">app/</span>
+├── <span class="k">backend/</span>
+│   ├── <span class="k">api/</span>          <span class="c">routes: chat.py, rag.py, models.py, health.py, voice.py (WebRTC SDP)</span>
+│   ├── <span class="k">core/</span>         <span class="c">backend config, embedding helpers, DEFAULT_RAG_CONFIG</span>
+│   └── <span class="k">models/</span>       <span class="c">Pydantic request/response models</span>
+├── <span class="k">core/</span>           <span class="c">shared utils: env detection, RAG formats, text markup</span>
+├── <span class="k">services/</span>       <span class="c">business logic: llm_gateway, rag_service, voice_pipeline, …</span>
+├── <span class="k">ingestion/</span>     <span class="c">file_ingest, document processors, OCR extractors</span>
+└── <span class="k">skills/</span>         <span class="c">pluggable chat &amp; RAG skill routing</span>
+
 <span class="k">nextjs-frontend/src/</span>
-  app/           <span class="c"># App Router pages &amp; layouts</span>
-  components/    <span class="c"># shadcn/ui components</span>
-  hooks/         <span class="c"># custom React hooks</span>
-  lib/           <span class="c"># API clients &amp; utilities</span>
-<span class="c">main.py</span>            <span class="c"># FastAPI entry (lifespan, route registration)</span>
-<span class="c">config.py</span>          <span class="c"># global Config (env vars, paths, tuning)</span>
+├── <span class="k">app/</span>           <span class="c">App Router pages &amp; layouts</span>
+├── <span class="k">components/</span>    <span class="c">shadcn/ui components</span>
+├── <span class="k">hooks/</span>         <span class="c">custom React hooks</span>
+└── <span class="k">lib/</span>           <span class="c">API clients &amp; utilities</span>
+
+<span class="c">main.py</span>            <span class="c">FastAPI entry (lifespan, route registration)</span>
+<span class="c">config.py</span>          <span class="c">global Config (env vars, paths, tuning)</span>
     </div>
 
     <h2>Key design patterns</h2>
@@ -73,7 +75,7 @@ description: >-
     <p>
       Chat and RAG requests route through <code>ChatSkillRegistry</code> /
       <code>RAGSkillRegistry</code>. Each skill implements <code>supports()</code>,
-      <code>validate()</code>, and <code>stream()</code> — add new capabilities
+      <code>validate()</code>, and <code>stream()</code>, so you can add new capabilities
       without touching the API routes.
     </p>
 
@@ -102,9 +104,37 @@ description: >-
     <p>
       Browser and server establish a WebRTC peer connection; the browser POSTs an SDP
       offer to <code>POST /api/voice/offer</code>. A Pipecat pipeline runs in the
-      background — Whisper STT + Kokoro TTS + LLM. Transcripts and control events flow
+      background, with Whisper STT + Kokoro TTS + LLM. Transcripts and control events flow
       back over the WebRTC data channel. <strong>Voice is a separate pipeline, not a
-      Skill</strong> — do not route it through the skill layer.
+      Skill</strong>. Do not route it through the skill layer.
+    </p>
+
+    <h2>How a request travels</h2>
+    <p>
+      A chat message is a good example of the moving parts. The browser POSTs to
+      <code>POST /api/chat</code>, and <code>chat.py</code> picks a skill from the
+      <code>ChatSkillRegistry</code> based on the request. The skill calls the
+      <code>llm_gateway</code> to reach a model, streams tokens back to the route, and
+      the route forwards them to the browser over Server-Sent Events. RAG and web
+      search follow the same shape, with an extra retrieval step before the model is
+      called.
+    </p>
+
+    <h2>Local development tips</h2>
+    <ul>
+      <li><strong>Hot reload.</strong> The backend runs with <code>uvicorn --reload</code> and the frontend with <code>npm run dev</code>; both rebuild on save.</li>
+      <li><strong>Start with a small local model.</strong> <code>gemma3:1b</code> through Ollama keeps everything on your machine while you build.</li>
+      <li><strong>Read the logs.</strong> Set <code>LOG_LEVEL=DEBUG</code> to see request routing, skill selection, and RAG retrieval scores.</li>
+      <li><strong>Containers are optional.</strong> <code>make dev</code> gives you the same stack with hot-reload if you would rather not manage Python and Node versions yourself.</li>
+    </ul>
+
+    <h2>Extending LiteMindUI</h2>
+    <p>
+      The skill layer is the main extension point. To add a capability, write a class
+      that implements <code>supports()</code>, <code>validate()</code>, and
+      <code>stream()</code>, then register it with the relevant registry. The API
+      routes never change, so new features stay isolated and testable. Voice is the one
+      intentional exception: it runs as its own Pipecat pipeline, not through a skill.
     </p>
 
     <h2>LLM provider backends</h2>

--- a/site/index.md
+++ b/site/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: LiteMindUI — your private AI workspace
+title: "LiteMindUI: your private AI workspace"
 permalink: /
 description: >-
   LiteMindUI is a friendly, private AI workspace you run on your own computer:
@@ -10,7 +10,7 @@ description: >-
 <section class="hero">
   <div class="container">
     <p class="eyebrow">Private · Local-first · Open source</p>
-    <h1>Your own AI workspace —<br>private, friendly, and easy</h1>
+    <h1>Your own AI workspace<br>private, friendly, and easy</h1>
     <p class="lead">
       LiteMindUI lets you chat, ask questions about <em>your own files</em>,
       search the web, and even talk out loud with an AI that runs on your
@@ -29,7 +29,7 @@ description: >-
       <h2>What is LiteMindUI?</h2>
       <p>
         Think of it as a friendly helper that lives on your computer. You type
-        or speak to it, and it answers, writes, and finds things for you — using
+        or speak to it, and it answers, writes, and finds things for you, using
         either a smart AI model on your machine or one from the internet, your
         choice.
       </p>
@@ -46,7 +46,7 @@ description: >-
         <div class="icon">📄</div>
         <h3>Ask your documents</h3>
         <p>Drop in your PDFs, notes, or reports and ask questions about them.
-        "What did we decide in the meeting notes?" — it knows.</p>
+        Ask "What did we decide in the meeting notes?" and it will tell you.</p>
       </div>
       <div class="card">
         <div class="icon">🌐</div>
@@ -58,13 +58,13 @@ description: >-
         <div class="icon">🎙️</div>
         <h3>Talk out loud</h3>
         <p>Turn on voice mode and just speak. It listens, thinks, and replies
-        with a natural voice — like a phone call with your assistant.</p>
+        with a natural voice, like a phone call with your assistant.</p>
       </div>
     </div>
 
     <figure class="demo">
       <img src="{{ site.baseurl }}/assets/demo.gif" alt="Short demo of LiteMindUI in action">
-      <figcaption>A quick look at LiteMindUI — chatting, asking documents, and more.</figcaption>
+      <figcaption>A quick look at LiteMindUI: chatting, asking documents, and more.</figcaption>
     </figure>
   </div>
 </section>
@@ -108,7 +108,7 @@ description: >-
   <div class="container">
     <div class="section-head">
       <h2>How do I get started?</h2>
-      <p>Three simple steps. The details live in the project README — here is
+      <p>Three simple steps. The details live in the project README, and here is
       the friendly version.</p>
     </div>
     <div class="steps">
@@ -148,9 +148,52 @@ description: >-
   <div class="container prose" style="margin:0 auto;text-align:center;">
     <h2>Curious about how it works?</h2>
     <p style="max-width:640px;margin:0 auto;">
-      If you like computers and want to see the engines under the hood — the
-      architecture, the APIs, and the design — we wrote a
+      If you like computers and want to see the engines under the hood,
+      including the architecture, the APIs, and the design, we wrote a
       <a href="{{ site.baseurl }}/developer/">Developer guide</a> just for you.
     </p>
+  </div>
+</section>
+
+<section class="block enterprise">
+  <div class="container prose" style="margin:0 auto;text-align:center;">
+    <h2>Building something bigger?</h2>
+    <p style="max-width:680px;margin:0 auto;">
+      LiteMindUI is free and open source, and a great fit for personal use and small
+      teams. If you are rolling it out across a company, or need it to meet stricter
+      requirements, I offer <strong>enterprise support</strong> shaped around how your
+      organisation actually works.
+    </p>
+
+    <div class="cards" style="margin-top:30px;text-align:left;">
+      <div class="card">
+        <div class="icon">🛡️</div>
+        <h3>Private, on-prem deployment</h3>
+        <p>Run entirely inside your own network, with no data leaving your perimeter and no third-party APIs required.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🔐</div>
+        <h3>SSO &amp; access control</h3>
+        <p>Connect your identity provider and decide exactly who can see what, down to workspace and document level.</p>
+      </div>
+      <div class="card">
+        <div class="icon">📈</div>
+        <h3>SLAs &amp; priority support</h3>
+        <p>Guaranteed response times and a direct line to me when something business-critical is on the line.</p>
+      </div>
+      <div class="card">
+        <div class="icon">🧩</div>
+        <h3>Custom integrations</h3>
+        <p>Wire up your internal tools, private models, and data sources, plus features built to your spec.</p>
+      </div>
+    </div>
+
+    <div class="ent-cta">
+      <p>
+        Have a use case in mind, or want to see what is possible for your team? Reach
+        out and we can talk through how LiteMindUI can support your business.
+      </p>
+      <a class="btn btn-solid" href="mailto:debabrata.mishra641@gmail.com?subject=LiteMindUI%20enterprise%20support">Email me about enterprise support</a>
+    </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Updates to the GitHub Pages site (`site/`), built and verified locally with `jekyll build`.

- **Copy polish:** removed unnecessary em-dashes (the "LLM-generated" tell) across the home page, Developer guide, and config/footer copy.
- **Developer page tree:** the directory layout was collapsing because `.tree` lacked `white-space: pre`. Fixed the CSS and rewrote it as a clean ASCII tree with `├── / └── / │` connectors.
- **More developer content:** added *How a request travels*, *Local development tips*, and *Extending LiteMindUI* sections.
- **Enterprise CTA:** new closing section on the home page with benefit cards and a `mailto:` contact (debabrata.mishra641@gmail.com).
- **Light/dark theme:** added a sun/moon toggle in the nav. Honors `prefers-color-scheme` on first visit, persists choice in `localStorage`, and sets the theme before paint to avoid a flash.

## Test plan
- [ ] Build locally: `cd site && jekyll build` (passes)
- [ ] Toggle light/dark and reload (choice persists)
- [ ] Check the Developer page tree renders with indentation
- [ ] Verify the enterprise CTA email link

## Note
The enterprise feature copy is suggested framing — adjust the wording/email angle if you want a different sales message before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)