### PR TITLE
Potential fix for code scanning alert no. 47: Information exposure through an exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -517,12 +517,13 @@ async def rag_upload(files: List[UploadFile] = File(...), chunk_size: int = Form
 
             # Sanitize filename to prevent path traversal
             safe_filename = sanitize_filename(up.filename or "")
-        except ValueError as e:
+        except ValueError:
+            logger.exception("Filename validation failed for upload: %s", up.filename)
             results.append(
                 {
                     "filename": up.filename,
                     "status": "error",
-                    "message": f"Invalid filename: {str(e)}",
+                    "message": "Invalid filename",
                     "chunks_created": 0,
                 }
             )
@@ -547,12 +548,13 @@ async def rag_upload(files: List[UploadFile] = File(...), chunk_size: int = Form
             upload_resolved = UPLOAD_FOLDER.resolve()
             if not str(dest_resolved).startswith(str(upload_resolved)):
                 raise ValueError("Path traversal attempt detected")
-        except (ValueError, OSError, RuntimeError) as e:
+        except (ValueError, OSError, RuntimeError):
+            logger.exception("Security validation failed for upload path: %s", up.filename)
             results.append(
                 {
                     "filename": up.filename,
                     "status": "error",
-                    "message": f"Security error: {str(e)}",
+                    "message": "Security validation failed",
                     "chunks_created": 0,
                 }
             )


### PR DESCRIPTION
Potential fix for [https://github.com/debabratamishra/litemind-ui/security/code-scanning/47](https://github.com/debabratamishra/litemind-ui/security/code-scanning/47)

The best fix is to stop embedding `str(e)` (or any raw exception detail) into user responses, and instead:

1. Log the exception server-side with `logger.exception(...)` (or `logger.warning(..., exc_info=True)`).
2. Return a generic, non-sensitive error message to the client.

In `main.py`, within `rag_upload`:
- Update the `except ValueError as e` block around lines 520–529 so `"message"` is a fixed safe string (for example, `"Invalid filename"`), and add server-side logging with exception context.
- Update the `except (ValueError, OSError, RuntimeError) as e` block around lines 550–559 so `"message"` is a fixed safe string (for example, `"Security validation failed"`), and add server-side logging with exception context.

This single change addresses both alert variants because both taint paths originate from exception-to-response string interpolation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
