### PR TITLE
feat: persistent user memory across chat, RAG, and voice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,8 @@ PR labels `patch` (default), `minor`, `major` control the bump type.
 - Sanitise all file names and paths using `app/backend/api/security_utils.py`
   (`sanitize_filename`, `validate_file_size`) for any upload handling.
 - Use parameterised queries. Never concatenate user input into SQL or shell commands.
+- Any new persisted data must be scoped by `user_id` (see `conversation_store.py` and
+  `user_memory_store.py`); never add user-keyed tables without the FK + user filter.
 - Do not log secrets, API keys, or sensitive user data.
 - Do not add new CORS origins without explicit approval.
 - The `SECRET_KEY` default in `.env.example` is a placeholder — remind users to rotate it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,15 +68,18 @@ The frontend calls the backend exclusively over HTTP. They share no Python impor
 app/
   backend/
     api/          Route handlers: chat.py, rag.py, models.py, health.py, security_utils.py, voice.py (WebRTC SDP signaling)
+      memory.py   /api/memory CRUD (user-level persistent memory)
     core/         Backend-specific config, embedding helpers, BackendConfig, DEFAULT_RAG_CONFIG
     models/       Pydantic request/response models
+    user_memory_store.py  Postgres user-memory persistence (user_memories table)
   core/           Shared utilities: environment detection, RAG formats, text markup
   services/       Backend business logic
     llm_gateway.py          Unified LLM transport (LiteLLM + Ollama direct client)
     rag_service.py          ChromaDB + BM25 hybrid retrieval, ingestion, answer composition
     rag_multi_agent.py      CrewAI multi-agent RAG orchestrator
     conversation_memory.py  Multi-turn memory with auto-summarisation
-    conversation_db.py      SQLite conversation persistence
+    conversation_db.py      Legacy SQLite persistence (canonical store: PostgreSQL via app/backend/conversation_store.py)
+    user_memory_service.py  Persistent user memory: prompt block, LLM extraction, orchestration
     web_search_service.py   SerpAPI REST client
     web_search_crew.py      CrewAI web-search orchestrator
     speech_service.py       STT via Whisper (transformers)
@@ -120,7 +123,16 @@ Chat and RAG requests route through `ChatSkillRegistry` / `RAGSkillRegistry`. Ea
 ChromaDB vector store + BM25 keyword retrieval (hybrid search). Configurable embedding providers (sentence-transformers, Ollama, OpenRouter, Nvidia NIM). Documents: format detection → extraction → chunking → embedding → indexing.
 
 **Conversation Memory** (`app/services/conversation_memory.py`)
-Session-based multi-turn context. Summarises older messages when token count exceeds 75 % of the 24 K context limit. Persisted in SQLite.
+Session-based multi-turn context. Summarises older messages when token count exceeds 75 % of the 24 K context limit. Persisted in PostgreSQL via `app/backend/conversation_store.py` (`Config.DATABASE_URL`); `conversation_db.py` is legacy.
+
+### Persistent user memory (`app/backend/user_memory_store.py`, `app/services/user_memory_service.py`)
+Per-user durable memory in Postgres (`user_memories`, FK to `users` with ON DELETE CASCADE).
+After each chat/voice exchange a fire-and-forget task asks the LLM gateway (request's own
+backend/model) for JSON ops (add/update/delete, ≤3/turn) and applies them; extraction failure
+never affects the response. On every chat/RAG/voice request the backend loads the user's
+memories and prepends an "About the user" system block (cap 50). Explicit "remember that…"
+requests are handled by the same extraction prompt. Manual management: `/api/memory` CRUD +
+Settings → Memory panel. Distinct from session-scoped `conversation_memory.py`.
 
 **Generative UI** (`app/backend/api/chat.py`)
 When `enable_generative_ui` is set, the LLM emits `` `ui:component_name` `` fenced blocks. The Next.js frontend renders these as charts, tables, metrics, progress bars, and iframe apps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Session-based multi-turn context. Summarises older messages when token count exc
 Per-user durable memory in Postgres (`user_memories`, FK to `users` with ON DELETE CASCADE).
 After each chat/voice exchange a fire-and-forget task asks the LLM gateway (request's own
 backend/model) for JSON ops (add/update/delete, ≤3/turn) and applies them; extraction failure
-never affects the response. On every chat/RAG/voice request the backend loads the user's
+never affects the response. On every chat/RAG/voice request (except multi-agent RAG mode) the backend loads the user's
 memories and prepends an "About the user" system block (cap 50). Explicit "remember that…"
 requests are handled by the same extraction prompt. Manual management: `/api/memory` CRUD +
 Settings → Memory panel. Distinct from session-scoped `conversation_memory.py`.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ On first run, register an account at `/register`, then sign in at `/login`. SMTP
 - **Markdown rendering** — syntax-highlighted code blocks, GFM tables, and more via `react-markdown`
 - **RAG / Knowledge Base** — drag-and-drop file upload, duplicate detection, multi-agent and hybrid search options
 - **Web Search** — SerpAPI-grounded responses with inline streaming results
+- **Persistent personalization** — LiteMindUI remembers durable facts you share (preferences, projects, corrections) across sessions and providers, injects them into every new chat/RAG/voice conversation, and lets you manage them in Settings → Memory.
 - **Settings page** — model catalogue (local + cloud), backend configuration (Ollama, OpenRouter, Nvidia NIM), generation parameter tuning
 
 ## Repository layout

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ On first run, register an account at `/register`, then sign in at `/login`. SMTP
 - **Markdown rendering** — syntax-highlighted code blocks, GFM tables, and more via `react-markdown`
 - **RAG / Knowledge Base** — drag-and-drop file upload, duplicate detection, multi-agent and hybrid search options
 - **Web Search** — SerpAPI-grounded responses with inline streaming results
-- **Persistent personalization** — LiteMindUI remembers durable facts you share (preferences, projects, corrections) across sessions and providers, injects them into every new chat/RAG/voice conversation, and lets you manage them in Settings → Memory.
+- **Persistent personalization** — LiteMindUI remembers durable facts you share (preferences, projects, corrections) across sessions and providers, injects them into new chat/RAG/voice conversations (multi-agent RAG mode excluded), and lets you manage them in Settings → Memory.
 - **Settings page** — model catalogue (local + cloud), backend configuration (Ollama, OpenRouter, Nvidia NIM), generation parameter tuning
 
 ## Repository layout

--- a/app/backend/api/chat.py
+++ b/app/backend/api/chat.py
@@ -2,6 +2,7 @@
 Chat API endpoints with conversation memory support
 """
 
+import asyncio
 import json
 import logging
 from typing import Dict, List, Optional
@@ -23,6 +24,7 @@ from app.backend.models.api_models import (  # noqa: E402
 )
 from app.services.conversation_memory import get_memory_service  # noqa: E402
 from app.services.llm_gateway import complete_text, stream_completion  # noqa: E402
+from app.services.user_memory_service import load_memory_block, run_memory_update  # noqa: E402
 from app.services.web_search_service import WebSearchService  # noqa: E402
 from app.skills import chat_skill_registry  # noqa: E402
 
@@ -156,18 +158,25 @@ GENERATIVE_UI_SYSTEM_PROMPT = (
 )
 
 
-def _build_messages_with_history(request: ChatRequestEnhanced) -> List[Dict[str, str]]:
+def _build_messages_with_history(
+    request: ChatRequestEnhanced, memory_block: Optional[str] = None
+) -> List[Dict[str, str]]:
     """
     Build the messages list including conversation history and summary.
     Also applies voice mode optimizations if is_voice_mode is True.
 
     Args:
         request: The chat request with optional history/summary
+        memory_block: Pre-formatted persistent user-memory block (may be empty)
 
     Returns:
         List of messages ready for LLM
     """
     messages = []
+
+    # Persistent user memory comes first so later system prompts can refine it
+    if memory_block:
+        messages.append({"role": "system", "content": memory_block})
 
     # Add voice mode system prompt if voice mode is active
     if request.is_voice_mode:
@@ -249,7 +258,7 @@ async def chat_endpoint(request: ChatRequestEnhanced, user: User = Depends(get_c
     logger.info(f"Chat request - User: {user.id}, Backend: {request.backend}, Model: {request.model}")
 
     try:
-        return await _handle_chat_request(request)
+        return await _handle_chat_request(request, user_id=user.id)
 
     except Exception:
         logger.exception("Chat endpoint error")
@@ -263,7 +272,7 @@ async def chat_stream(request: ChatRequestEnhanced, user: User = Depends(get_cur
 
     async def event_generator():
         try:
-            async for chunk in _stream_chat_response(request):
+            async for chunk in _stream_chat_response(request, user_id=user.id):
                 payload = json.dumps({"chunk": chunk}, ensure_ascii=False)
                 yield f"data: {payload}\n\n"
 
@@ -275,10 +284,10 @@ async def chat_stream(request: ChatRequestEnhanced, user: User = Depends(get_cur
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
-async def _handle_chat_request(request: ChatRequestEnhanced) -> ChatResponse:
+async def _handle_chat_request(request: ChatRequestEnhanced, user_id: Optional[str] = None) -> ChatResponse:
     """Handle a chat request with conversation history."""
-    # Build messages with conversation history
-    messages = _build_messages_with_history(request)
+    memory_block = await load_memory_block(user_id) if user_id else ""
+    messages = _build_messages_with_history(request, memory_block=memory_block)
 
     # Adjust max_tokens: voice mode → short; GenUI mode → at least GENUI_MIN_MAX_TOKENS
     if request.is_voice_mode:
@@ -305,13 +314,27 @@ async def _handle_chat_request(request: ChatRequestEnhanced) -> ChatResponse:
         stop=request.stop,
     )
 
+    # Fire-and-forget memory update if user_id is provided
+    if user_id is not None:
+        asyncio.create_task(
+            run_memory_update(
+                user_id,
+                request.message,
+                response_text,
+                backend=request.backend,
+                model=request.model,
+                api_base=request.api_base,
+                api_key=request.api_key,
+            )
+        )
+
     return ChatResponse(response=response_text, model=request.model if request.model is not None else "default")
 
 
-async def _stream_chat_response(request: ChatRequestEnhanced):
+async def _stream_chat_response(request: ChatRequestEnhanced, user_id: Optional[str] = None):
     """Stream chat responses with conversation history."""
-    # Build messages with conversation history
-    messages = _build_messages_with_history(request)
+    memory_block = await load_memory_block(user_id) if user_id else ""
+    messages = _build_messages_with_history(request, memory_block=memory_block)
 
     # Adjust max_tokens: voice mode → short; GenUI mode → at least GENUI_MIN_MAX_TOKENS
     if request.is_voice_mode:

--- a/app/backend/api/memory.py
+++ b/app/backend/api/memory.py
@@ -1,0 +1,70 @@
+"""User-level persistent memory CRUD endpoints (all require authentication)."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.backend.api.auth_deps import User, get_current_user
+from app.backend.models.api_models import MemoryContentRequest, MemoryRecordResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/memory", tags=["memory"])
+
+
+def _get_user_memory_store():
+    from app.backend.user_memory_store import get_user_memory_store
+    return get_user_memory_store()
+
+
+def _response(record) -> MemoryRecordResponse:
+    return MemoryRecordResponse(
+        id=record.id,
+        content=record.content,
+        source=record.source,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+@router.get("", response_model=list[MemoryRecordResponse])
+async def list_memories(user: User = Depends(get_current_user)):
+    records = await _get_user_memory_store().list_memories(user.id)
+    return [_response(r) for r in records]
+
+
+@router.post("", response_model=MemoryRecordResponse)
+async def add_memory(request: MemoryContentRequest, user: User = Depends(get_current_user)):
+    content = request.content.strip()
+    if not content:
+        raise HTTPException(status_code=422, detail="Memory content cannot be empty")
+    store = _get_user_memory_store()
+    record = await store.add_memory(user.id, content, source="manual")
+    return _response(record)
+
+
+@router.put("/{memory_id}")
+async def update_memory(memory_id: str, request: MemoryContentRequest, user: User = Depends(get_current_user)):
+    content = request.content.strip()
+    if not content:
+        raise HTTPException(status_code=422, detail="Memory content cannot be empty")
+    updated = await _get_user_memory_store().update_memory(user.id, memory_id, content)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"status": "updated", "id": memory_id}
+
+
+@router.delete("/{memory_id}")
+async def delete_memory(memory_id: str, user: User = Depends(get_current_user)):
+    deleted = await _get_user_memory_store().delete_memory(user.id, memory_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"status": "deleted", "id": memory_id}
+
+
+@router.post("/clear")
+async def clear_memories(user: User = Depends(get_current_user)):
+    count = await _get_user_memory_store().clear_memories(user.id)
+    return {"status": "cleared", "deleted": count}

--- a/app/backend/models/api_models.py
+++ b/app/backend/models/api_models.py
@@ -4,7 +4,7 @@ API request and response models
 
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ChatMessage(BaseModel):
@@ -223,3 +223,15 @@ class MemoryStatsResponse(BaseModel):
     has_summary: bool
     max_context_tokens: int
     usage_percentage: float
+
+
+class MemoryContentRequest(BaseModel):
+    content: str = Field(..., min_length=1, description="Memory text (trimmed server-side)")
+
+
+class MemoryRecordResponse(BaseModel):
+    id: str
+    content: str
+    source: str
+    created_at: str
+    updated_at: str

--- a/app/backend/models/api_models.py
+++ b/app/backend/models/api_models.py
@@ -226,7 +226,12 @@ class MemoryStatsResponse(BaseModel):
 
 
 class MemoryContentRequest(BaseModel):
-    content: str = Field(..., min_length=1, description="Memory text (trimmed server-side)")
+    content: str = Field(
+        ...,
+        min_length=1,
+        max_length=500,
+        description="Memory text (1-500 chars, trimmed server-side)",
+    )
 
 
 class MemoryRecordResponse(BaseModel):

--- a/app/backend/user_memory_store.py
+++ b/app/backend/user_memory_store.py
@@ -1,0 +1,168 @@
+"""
+User-scoped persistent memory store backed by PostgreSQL (asyncpg).
+
+Mirrors ``conversation_store.py``: lazy connection-pool singleton, idempotent
+schema init, and every query filtered by ``user_id`` so one user can never
+read or mutate another user's memories.
+
+Rows are deleted automatically when the owning user is removed from the
+``users`` table (ON DELETE CASCADE).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import List, Optional
+
+import asyncpg
+
+from app.backend.core.config import Config
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS user_memories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    content TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'auto',
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_memories_user_id
+    ON user_memories(user_id);
+"""
+
+
+@dataclass
+class UserMemoryRecord:
+    id: str
+    user_id: str
+    content: str
+    source: str
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "content": self.content,
+            "source": self.source,
+            "created_at": str(self.created_at),
+            "updated_at": str(self.updated_at),
+        }
+
+
+class UserMemoryStore:
+    """CRUD access to the ``user_memories`` table, always scoped by user."""
+
+    def __init__(self, dsn: Optional[str] = None):
+        self._dsn = dsn or Config.DATABASE_URL
+        self._pool: Optional[asyncpg.Pool] = None
+
+    async def _get_pool(self) -> asyncpg.Pool:
+        if self._pool is None:
+            self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=10)
+        return self._pool
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+    async def init_schema(self) -> None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(SCHEMA_SQL)
+
+    @staticmethod
+    def _record(row: asyncpg.Record) -> UserMemoryRecord:
+        return UserMemoryRecord(
+            id=str(row["id"]),
+            user_id=str(row["user_id"]),
+            content=row["content"],
+            source=row["source"],
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    async def list_memories(self, user_id: str, limit: int = 50) -> List[UserMemoryRecord]:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, user_id, content, source, created_at, updated_at
+                FROM user_memories WHERE user_id = $1
+                ORDER BY created_at DESC LIMIT $2
+                """,
+                uuid.UUID(user_id),
+                limit,
+            )
+        return [self._record(r) for r in rows]
+
+    async def add_memory(self, user_id: str, content: str, source: str = "auto") -> UserMemoryRecord:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO user_memories (user_id, content, source)
+                VALUES ($1, $2, $3)
+                RETURNING id, user_id, content, source, created_at, updated_at
+                """,
+                uuid.UUID(user_id),
+                content,
+                source,
+            )
+        return self._record(row)
+
+    async def update_memory(self, user_id: str, memory_id: str, content: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                UPDATE user_memories SET content = $3, updated_at = NOW()
+                WHERE id = $2 AND user_id = $1
+                RETURNING id
+                """,
+                uuid.UUID(user_id),
+                uuid.UUID(memory_id),
+                content,
+            )
+        return row is not None
+
+    async def delete_memory(self, user_id: str, memory_id: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "DELETE FROM user_memories WHERE id = $2 AND user_id = $1 RETURNING id",
+                uuid.UUID(user_id),
+                uuid.UUID(memory_id),
+            )
+        return row is not None
+
+    async def clear_memories(self, user_id: str) -> int:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM user_memories WHERE user_id = $1", uuid.UUID(user_id)
+            )
+        # asyncpg returns e.g. "DELETE 5"
+        try:
+            return int(result.split()[-1])
+        except (ValueError, IndexError):
+            return 0
+
+
+_store_instance: Optional[UserMemoryStore] = None
+
+
+def get_user_memory_store() -> UserMemoryStore:
+    """Get the process-wide UserMemoryStore singleton."""
+    global _store_instance
+    if _store_instance is None:
+        _store_instance = UserMemoryStore()
+    return _store_instance

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -1558,6 +1558,7 @@ class RAGService:
             seed: Optional[int] = None,
             stop: Optional[list] = None,
             is_voice_mode: bool = False,
+            memory_block: Optional[str] = None,
         ):
             """Answer a query using semantic or hybrid retrieval and stream model tokens.
 
@@ -1620,6 +1621,10 @@ class RAGService:
                 llm_messages.append(
                     {"role": "system", "content": f"Summary of previous conversation:\n{conversation_summary}"}
                 )
+
+            # Persistent user memory (may be empty)
+            if memory_block:
+                llm_messages.append({"role": "system", "content": memory_block})
 
             # Add conversation history
             llm_messages.extend(messages)

--- a/app/services/user_memory_service.py
+++ b/app/services/user_memory_service.py
@@ -10,9 +10,13 @@ user-visible response.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Dict, List, Optional
+
+from app.backend.user_memory_store import get_user_memory_store
+from app.services.llm_gateway import complete_text
 
 logger = logging.getLogger(__name__)
 
@@ -80,3 +84,125 @@ def parse_memory_ops(raw: str) -> List[Dict[str, Any]]:
         if len(ops) >= MAX_MEMORY_OPS_PER_TURN:
             break
     return ops
+
+
+_EXTRACTION_SYSTEM_PROMPT = """You maintain long-term memory for a personal assistant. \
+Given a conversation exchange and the user's existing memories, decide what durable facts about the \
+user should be stored, updated, or removed.
+
+Return ONLY a JSON array. Each element is exactly one of:
+{"op": "add", "content": "<new memory, one concise sentence>"}
+{"op": "update", "id": "<existing memory id>", "content": "<corrected memory>"}
+{"op": "delete", "id": "<existing memory id that is now wrong or obsolete>"}
+
+Rules:
+- Store only durable facts: the user's identity, stable preferences, ongoing projects or goals, \
+corrections to existing memories, and explicit requests to remember something.
+- Never store secrets, credentials, API keys, passwords, or transient task details.
+- Prefer updating an existing memory over adding a near-duplicate.
+- At most 3 operations. Return [] when nothing durable was shared."""
+
+
+def _build_extraction_messages(
+    user_message: str, assistant_message: str, existing: List[Any]
+) -> List[Dict[str, str]]:
+    existing_lines = "\n".join(
+        f'- id={getattr(m, "id", "?")}: {getattr(m, "content", "")}' for m in existing
+    )
+    return [
+        {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Existing memories:\n{existing_lines or '(none)'}\n\n"
+                f"User said:\n{user_message}\n\n"
+                f"Assistant replied:\n{assistant_message}"
+            ),
+        },
+    ]
+
+
+async def extract_memory_ops(
+    user_message: str,
+    assistant_message: str,
+    existing: List[Any],
+    *,
+    backend: Optional[str] = None,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Ask the LLM which memories to add/update/delete; [] on any failure."""
+    if not user_message.strip():
+        return []
+    messages = _build_extraction_messages(user_message, assistant_message, existing)
+    try:
+        raw = await asyncio.wait_for(
+            complete_text(
+                messages,
+                backend=backend,
+                model=model,
+                api_base=api_base,
+                api_key=api_key,
+                max_tokens=300,
+            ),
+            timeout=MEMORY_EXTRACTION_TIMEOUT_SECONDS,
+        )
+    except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001 — extraction must never raise
+        logger.warning("Memory extraction failed/skipped: %s", exc)
+        return []
+    return parse_memory_ops(raw)
+
+
+async def apply_memory_ops(store: Any, user_id: str, ops: List[Dict[str, Any]]) -> None:
+    """Apply validated ops to the store; unknown ids are ignored by the store."""
+    for op in ops:
+        if op["op"] == "add":
+            await store.add_memory(user_id, op["content"], source="auto")
+        elif op["op"] == "update":
+            await store.update_memory(user_id, op["id"], op["content"])
+        elif op["op"] == "delete":
+            await store.delete_memory(user_id, op["id"])
+
+
+async def run_memory_update(
+    user_id: str,
+    user_message: str,
+    assistant_message: str,
+    *,
+    backend: Optional[str] = None,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> None:
+    """Extract and apply memory ops for one completed exchange. Never raises."""
+    try:
+        store = get_user_memory_store()
+        existing = await store.list_memories(user_id)
+        ops = await extract_memory_ops(
+            user_message,
+            assistant_message,
+            existing,
+            backend=backend,
+            model=model,
+            api_base=api_base,
+            api_key=api_key,
+        )
+        await apply_memory_ops(store, user_id, ops)
+        if ops:
+            logger.info("User memory updated for user %s (%d ops)", user_id, len(ops))
+    except Exception as exc:  # noqa: BLE001 — fire-and-forget task must be self-contained
+        logger.warning("User memory update failed for user %s: %s", user_id, exc)
+
+
+async def load_memory_block(user_id: Optional[str]) -> str:
+    """Load and format the user's memories for prompt injection ("" on failure)."""
+    if not user_id:
+        return ""
+    try:
+        store = get_user_memory_store()
+        memories = await store.list_memories(user_id)
+        return build_memory_block(memories)
+    except Exception as exc:  # noqa: BLE001 — degraded response beats failed response
+        logger.warning("Failed to load user memory for user %s: %s", user_id, exc)
+        return ""

--- a/app/services/user_memory_service.py
+++ b/app/services/user_memory_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import uuid
 from typing import Any, Dict, List, Optional
 
 from app.backend.user_memory_store import get_user_memory_store
@@ -50,6 +51,10 @@ def _valid_op(item: Any) -> Optional[Dict[str, Any]]:
         memory_id = item.get("id")
         if not isinstance(memory_id, str) or not memory_id:
             return None
+        try:
+            uuid.UUID(memory_id)
+        except ValueError:
+            return None  # store would raise on a mangled id; drop just this op
         if op == "delete":
             return {"op": "delete", "id": memory_id}
         content = item.get("content")
@@ -155,14 +160,21 @@ async def extract_memory_ops(
 
 
 async def apply_memory_ops(store: Any, user_id: str, ops: List[Dict[str, Any]]) -> None:
-    """Apply validated ops to the store; unknown ids are ignored by the store."""
+    """Apply validated ops to the store; unknown ids are ignored by the store.
+
+    Each op is isolated so one failure (transient DB error, race-deleted id)
+    cannot abort the remaining ops in the batch.
+    """
     for op in ops:
-        if op["op"] == "add":
-            await store.add_memory(user_id, op["content"], source="auto")
-        elif op["op"] == "update":
-            await store.update_memory(user_id, op["id"], op["content"])
-        elif op["op"] == "delete":
-            await store.delete_memory(user_id, op["id"])
+        try:
+            if op["op"] == "add":
+                await store.add_memory(user_id, op["content"], source="auto")
+            elif op["op"] == "update":
+                await store.update_memory(user_id, op["id"], op["content"])
+            elif op["op"] == "delete":
+                await store.delete_memory(user_id, op["id"])
+        except Exception as exc:
+            logger.warning("Memory op %s failed (skipped): %s", op["op"], exc)
 
 
 async def run_memory_update(

--- a/app/services/user_memory_service.py
+++ b/app/services/user_memory_service.py
@@ -1,0 +1,82 @@
+"""
+User-level persistent memory: prompt-block formatting, extraction-op parsing,
+extraction via the LLM gateway, and the fire-and-forget update orchestration.
+
+All LLM work goes through ``app.services.llm_gateway`` using the request's own
+backend/model config, so behavior is identical on Ollama, OpenRouter, and
+Nvidia NIM. Extraction failures are logged and skipped — they never affect the
+user-visible response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_MEMORY_OPS_PER_TURN = 3
+MEMORY_EXTRACTION_TIMEOUT_SECONDS = 15
+MAX_MEMORY_CONTENT_LENGTH = 500
+
+MEMORY_BLOCK_HEADER = "About the user (persistent memory; use when relevant):"
+
+
+def build_memory_block(memories: List[Any]) -> str:
+    """Format memory records into a system-prompt block ("" when none)."""
+    contents = [getattr(m, "content", "") for m in memories if getattr(m, "content", "")]
+    if not contents:
+        return ""
+    lines = [MEMORY_BLOCK_HEADER] + [f"- {c}" for c in contents]
+    return "\n".join(lines)
+
+
+def _valid_op(item: Any) -> Optional[Dict[str, Any]]:
+    """Return a normalized op dict, or None if the item is malformed."""
+    if not isinstance(item, dict):
+        return None
+    op = item.get("op")
+    if op == "add":
+        content = item.get("content")
+        if isinstance(content, str) and content.strip():
+            return {"op": "add", "content": content.strip()[:MAX_MEMORY_CONTENT_LENGTH]}
+        return None
+    if op in ("update", "delete"):
+        memory_id = item.get("id")
+        if not isinstance(memory_id, str) or not memory_id:
+            return None
+        if op == "delete":
+            return {"op": "delete", "id": memory_id}
+        content = item.get("content")
+        if isinstance(content, str) and content.strip():
+            return {"op": "update", "id": memory_id, "content": content.strip()[:MAX_MEMORY_CONTENT_LENGTH]}
+        return None
+    return None
+
+
+def parse_memory_ops(raw: str) -> List[Dict[str, Any]]:
+    """Parse the extraction LLM's output into validated ops (max 3)."""
+    if not raw or not raw.strip():
+        return []
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.debug("Memory extraction returned non-JSON output, skipping")
+        return []
+    if not isinstance(data, list):
+        return []
+    ops = []
+    for item in data:
+        op = _valid_op(item)
+        if op is not None:
+            ops.append(op)
+        if len(ops) >= MAX_MEMORY_OPS_PER_TURN:
+            break
+    return ops

--- a/app/services/voice_pipeline.py
+++ b/app/services/voice_pipeline.py
@@ -8,6 +8,7 @@ Events -> WebRTC data channel (SmallWebRTCConnection.send_app_message)
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 from dataclasses import dataclass
@@ -45,6 +46,7 @@ from pipecat.workers.runner import WorkerRunner
 from app.services.llm_gateway import stream_completion
 from app.services.speech_service import get_speech_service
 from app.services.tts_service import get_tts_service
+from app.services.user_memory_service import load_memory_block, run_memory_update
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +76,15 @@ class VoiceSettings:
     voice: str | None = None
     system_instruction: str = DEFAULT_SYSTEM_INSTRUCTION
     user_id: str | None = None  # Owning user (for session/transcript isolation)
+
+
+async def apply_memory_to_voice_settings(settings: VoiceSettings) -> None:
+    """Fold the user's persistent memory into the voice system instruction."""
+    if not settings.user_id:
+        return
+    block = await load_memory_block(settings.user_id)
+    if block:
+        settings.system_instruction = f"{settings.system_instruction}\n\n{block}"
 
 
 class BackendWhisperSTTService(SegmentedSTTService):
@@ -163,6 +174,10 @@ class BackendLLMService(BaseOpenAILLMService):
             {"role": m.get("role", "user"), "content": m.get("content", "")}
             for m in raw_messages
         ]
+        last_user = next(
+            (m["content"] for m in reversed(messages) if m.get("role") == "user"), ""
+        )
+        reply_parts: list[str] = []
         async for delta in stream_completion(
             messages,
             backend=self._voice_settings.backend,
@@ -173,7 +188,22 @@ class BackendLLMService(BaseOpenAILLMService):
             max_tokens=self._voice_settings.max_tokens,
         ):
             if delta:
+                reply_parts.append(delta)
                 await self.push_frame(LLMTextFrame(text=delta))
+
+        # Fire-and-forget memory extraction for this voice turn
+        if self._voice_settings.user_id and last_user and reply_parts:
+            asyncio.create_task(
+                run_memory_update(
+                    self._voice_settings.user_id,
+                    last_user,
+                    "".join(reply_parts),
+                    backend=self._voice_settings.backend,
+                    model=self._voice_settings.model,
+                    api_base=self._voice_settings.api_base,
+                    api_key=self._voice_settings.api_key,
+                )
+            )
 
 
 class UserTranscriptEmitter(FrameProcessor):
@@ -252,6 +282,7 @@ def build_voice_pipeline(connection: SmallWebRTCConnection, settings: VoiceSetti
 
 
 async def run_voice_pipeline(connection: SmallWebRTCConnection, settings: VoiceSettings):
+    await apply_memory_to_voice_settings(settings)
     pipeline, transport = build_voice_pipeline(connection, settings)
     worker = PipelineWorker(pipeline, params=PipelineParams(enable_metrics=False))
     runner = WorkerRunner(handle_sigint=False)

--- a/app/skills/base.py
+++ b/app/skills/base.py
@@ -42,5 +42,5 @@ class StreamingRAGSkill(Protocol):
     def supports(self, request: Any) -> bool:
         """Return True when this skill should handle the request."""
 
-    def stream(self, request: Any, rag_service: Any) -> AsyncIterator[str]:
+    def stream(self, request: Any, rag_service: Any, memory_block: str | None = None) -> AsyncIterator[str]:
         """Yield streamed response chunks for the request."""

--- a/app/skills/rag.py
+++ b/app/skills/rag.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Optional
 
 from app.services.rag_multi_agent import CrewAIRAGOrchestrator, multi_agent_rag_available
 
@@ -25,7 +25,9 @@ class StandardRAGSkill:
     def supports(self, request: Any) -> bool:
         return not bool(getattr(request, "use_multi_agent", False))
 
-    async def stream(self, request: Any, rag_service: Any) -> AsyncIterator[str]:
+    async def stream(
+        self, request: Any, rag_service: Any, memory_block: Optional[str] = None
+    ) -> AsyncIterator[str]:
         async for chunk in rag_service.query(
             request.query,
             request.system_prompt,
@@ -34,6 +36,7 @@ class StandardRAGSkill:
             request.use_hybrid_search,
             request.model,
             conversation_summary=request.conversation_summary,
+            memory_block=memory_block,
             backend=request.backend,
             api_base=request.api_base,
             api_key=request.api_key,
@@ -62,12 +65,14 @@ class MultiAgentRAGSkill:
     def supports(self, request: Any) -> bool:
         return bool(getattr(request, "use_multi_agent", False))
 
-    async def stream(self, request: Any, rag_service: Any) -> AsyncIterator[str]:
+    async def stream(
+        self, request: Any, rag_service: Any, memory_block: Optional[str] = None
+    ) -> AsyncIterator[str]:
         available, detail = multi_agent_rag_available()
         if not available:
             logger.warning("Multi-agent RAG unavailable, falling back to standard RAG: %s", detail)
             yield self._fallback_message(detail)
-            async for chunk in self._fallback_skill.stream(request, rag_service):
+            async for chunk in self._fallback_skill.stream(request, rag_service, memory_block=memory_block):
                 yield chunk
             return
 
@@ -83,7 +88,7 @@ class MultiAgentRAGSkill:
             detail = str(exc)
             logger.warning("Multi-agent RAG initialization failed, falling back: %s", detail)
             yield self._fallback_message(detail)
-            async for chunk in self._fallback_skill.stream(request, rag_service):
+            async for chunk in self._fallback_skill.stream(request, rag_service, memory_block=memory_block):
                 yield chunk
             return
 

--- a/docs/superpowers/plans/2026-08-23-user-memory.md
+++ b/docs/superpowers/plans/2026-08-23-user-memory.md
@@ -1,0 +1,1941 @@
+# Persistent User Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persistent per-user memory (auto-extracted + manually managed) injected into chat, RAG, and voice conversations on every LLM provider.
+
+**Architecture:** Postgres table `user_memories` (asyncpg, mirroring `conversation_store.py`), a service module that formats memories into a system-prompt block and extracts new memories via `llm_gateway.complete_text` after each exchange, a CRUD router, and thin wiring at each surface. Extraction runs fire-and-forget and never blocks responses.
+
+**Tech Stack:** FastAPI, asyncpg/Postgres, LiteLLM gateway (existing), Next.js 16 + React 19 + vitest/testing-library.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-user-memory-design.md`
+
+## Global Constraints
+
+- Naming is always **user_memory** / `user_memories` — never reuse the session-scoped "memory" names (`conversation_memory`, `/api/chat/memory/*`).
+- Every store query filters by `user_id` (same isolation guarantee as `conversation_store.py`).
+- All LLM calls (extraction) go through `app/services/llm_gateway.py` with the request's own backend/model config — no provider-specific code anywhere.
+- Extraction failures are logged (WARNING) and skipped; they must never delay or fail a chat/RAG/voice response.
+- ≤3 memory ops per extraction; memories injected capped at 50 most recent.
+- Python: run `uv run ruff check .` and `uv run ty check app/backend app/services main.py` before finishing each backend task. Frontend: `npm run lint` inside `nextjs-frontend/`.
+- Do not touch `version.json`.
+
+## File Structure
+
+```
+app/backend/user_memory_store.py      CREATE  Postgres store (record + CRUD + singleton)
+app/services/user_memory_service.py   CREATE  block formatting, op parsing, extraction, orchestration
+app/backend/api/memory.py             CREATE  /api/memory CRUD router
+app/backend/models/api_models.py      MODIFY  request/response models for /api/memory
+main.py                               MODIFY  include memory router; RAG query loads memory block
+app/backend/api/chat.py               MODIFY  inject block; extraction triggers on /api/chat + /api/chat/stream
+app/skills/rag.py                     MODIFY  thread memory_block through both RAG skills
+app/services/rag_service.py           MODIFY  query(..., memory_block=None) injection
+app/services/voice_pipeline.py        MODIFY  inject at pipeline start; extraction per LLM turn
+nextjs-frontend/src/lib/types.ts      MODIFY  MemoryRecord type
+nextjs-frontend/src/lib/api.ts        MODIFY  memory API client functions
+nextjs-frontend/src/components/settings-panel.tsx  MODIFY  Memory section
+tests/test_user_memory_store.py       CREATE
+tests/test_user_memory_service.py     CREATE
+tests/test_memory_api.py              CREATE
+tests/test_user_memory_wiring.py      CREATE
+nextjs-frontend/src/components/memory-settings.test.tsx  CREATE
+```
+
+---
+
+### Task 1: UserMemoryStore (Postgres persistence)
+
+**Files:**
+- Create: `app/backend/user_memory_store.py`
+- Test: `tests/test_user_memory_store.py`
+
+**Interfaces:**
+- Consumes: `Config.DATABASE_URL` from `app.backend.core.config` (same import as `conversation_store.py`).
+- Produces: `UserMemoryRecord(id: str, user_id: str, content: str, source: str, created_at: str, updated_at: str)` with `.to_dict() -> dict`; `UserMemoryStore` with async methods `init_schema() -> None`, `list_memories(user_id: str, limit: int = 50) -> List[UserMemoryRecord]`, `add_memory(user_id: str, content: str, source: str = "auto") -> UserMemoryRecord`, `update_memory(user_id: str, memory_id: str, content: str) -> bool`, `delete_memory(user_id: str, memory_id: str) -> bool`, `clear_memories(user_id: str) -> int`; module function `get_user_memory_store() -> UserMemoryStore` (process-wide singleton).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Unit tests for UserMemoryStore.
+
+Uses an in-memory FakeStore subclass (same approach as
+tests/test_conversation_store.py) so no live PostgreSQL is required. The focus
+is user isolation: one user can never read or mutate another user's memories.
+"""
+
+import uuid
+
+import pytest
+
+from app.backend.user_memory_store import UserMemoryRecord, UserMemoryStore
+
+
+class FakeUserMemoryStore(UserMemoryStore):
+    """In-memory implementation of the same async interface."""
+
+    def __init__(self):
+        self.memories = {}  # id -> dict(row fields)
+
+    async def init_schema(self):
+        return None
+
+    async def list_memories(self, user_id, limit=50):
+        rows = [m for m in self.memories.values() if m["user_id"] == user_id]
+        rows.sort(key=lambda m: m["created_at"], reverse=True)
+        return [self._record(m) for m in rows[:limit]]
+
+    async def add_memory(self, user_id, content, source="auto"):
+        mid = str(uuid.uuid4())
+        row = {
+            "id": mid, "user_id": user_id, "content": content, "source": source,
+            "created_at": "2026-08-23T00:00:00", "updated_at": "2026-08-23T00:00:00",
+        }
+        self.memories[mid] = row
+        return self._record(row)
+
+    async def update_memory(self, user_id, memory_id, content):
+        m = self.memories.get(memory_id)
+        if not m or m["user_id"] != user_id:
+            return False
+        m["content"] = content
+        m["updated_at"] = "2026-08-23T01:00:00"
+        return True
+
+    async def delete_memory(self, user_id, memory_id):
+        m = self.memories.get(memory_id)
+        if not m or m["user_id"] != user_id:
+            return False
+        del self.memories[memory_id]
+        return True
+
+    async def clear_memories(self, user_id):
+        ids = [i for i, m in self.memories.items() if m["user_id"] == user_id]
+        for i in ids:
+            del self.memories[i]
+        return len(ids)
+
+    @staticmethod
+    def _record(m):
+        return UserMemoryRecord(**m)
+
+
+USER_A = str(uuid.uuid4())
+USER_B = str(uuid.uuid4())
+
+
+@pytest.mark.asyncio
+async def test_add_and_list_scoped_to_user():
+    store = FakeUserMemoryStore()
+    await store.add_memory(USER_A, "Prefers concise answers")
+    await store.add_memory(USER_B, "Works on robotics")
+    assert [m.content for m in await store.list_memories(USER_A)] == ["Prefers concise answers"]
+
+
+@pytest.mark.asyncio
+async def test_update_requires_owner():
+    store = FakeUserMemoryStore()
+    mem = await store.add_memory(USER_A, "Old fact")
+    assert await store.update_memory(USER_B, mem.id, "hijack") is False
+    assert await store.update_memory(USER_A, mem.id, "New fact") is True
+    assert (await store.list_memories(USER_A))[0].content == "New fact"
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_owner():
+    store = FakeUserMemoryStore()
+    mem = await store.add_memory(USER_A, "fact")
+    assert await store.delete_memory(USER_B, mem.id) is False
+    assert await store.delete_memory(USER_A, mem.id) is True
+    assert await store.list_memories(USER_A) == []
+
+
+@pytest.mark.asyncio
+async def test_clear_only_own():
+    store = FakeUserMemoryStore()
+    await store.add_memory(USER_A, "a1")
+    await store.add_memory(USER_A, "a2")
+    await store.add_memory(USER_B, "b1")
+    assert await store.clear_memories(USER_A) == 2
+    assert len(await store.list_memories(USER_B)) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_respects_limit_and_newest_first():
+    store = FakeUserMemoryStore()
+    for i in range(5):
+        await store.add_memory(USER_A, f"fact {i}")
+    rows = await store.list_memories(USER_A, limit=3)
+    assert len(rows) == 3
+    assert rows[0].content == "fact 4"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_user_memory_store.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.backend.user_memory_store'`
+
+- [ ] **Step 3: Write the store**
+
+```python
+"""
+User-scoped persistent memory store backed by PostgreSQL (asyncpg).
+
+Mirrors ``conversation_store.py``: lazy connection-pool singleton, idempotent
+schema init, and every query filtered by ``user_id`` so one user can never
+read or mutate another user's memories.
+
+Rows are deleted automatically when the owning user is removed from the
+``users`` table (ON DELETE CASCADE).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import List, Optional
+
+import asyncpg
+
+from app.backend.core.config import Config
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS user_memories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    content TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'auto',
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_memories_user_id
+    ON user_memories(user_id);
+"""
+
+
+@dataclass
+class UserMemoryRecord:
+    id: str
+    user_id: str
+    content: str
+    source: str
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "content": self.content,
+            "source": self.source,
+            "created_at": str(self.created_at),
+            "updated_at": str(self.updated_at),
+        }
+
+
+class UserMemoryStore:
+    """CRUD access to the ``user_memories`` table, always scoped by user."""
+
+    def __init__(self, dsn: Optional[str] = None):
+        self._dsn = dsn or Config.DATABASE_URL
+        self._pool: Optional[asyncpg.Pool] = None
+
+    async def _get_pool(self) -> asyncpg.Pool:
+        if self._pool is None:
+            self._pool = await asyncpg.create_pool(self._dsn, min_size=1, max_size=10)
+        return self._pool
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+
+    async def init_schema(self) -> None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(SCHEMA_SQL)
+
+    @staticmethod
+    def _record(row: asyncpg.Record) -> UserMemoryRecord:
+        return UserMemoryRecord(
+            id=str(row["id"]),
+            user_id=str(row["user_id"]),
+            content=row["content"],
+            source=row["source"],
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    async def list_memories(self, user_id: str, limit: int = 50) -> List[UserMemoryRecord]:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, user_id, content, source, created_at, updated_at
+                FROM user_memories WHERE user_id = $1
+                ORDER BY created_at DESC LIMIT $2
+                """,
+                uuid.UUID(user_id),
+                limit,
+            )
+        return [self._record(r) for r in rows]
+
+    async def add_memory(self, user_id: str, content: str, source: str = "auto") -> UserMemoryRecord:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                INSERT INTO user_memories (user_id, content, source)
+                VALUES ($1, $2, $3)
+                RETURNING id, user_id, content, source, created_at, updated_at
+                """,
+                uuid.UUID(user_id),
+                content,
+                source,
+            )
+        return self._record(row)
+
+    async def update_memory(self, user_id: str, memory_id: str, content: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                UPDATE user_memories SET content = $3, updated_at = NOW()
+                WHERE id = $2 AND user_id = $1
+                RETURNING id
+                """,
+                uuid.UUID(user_id),
+                uuid.UUID(memory_id),
+                content,
+            )
+        return row is not None
+
+    async def delete_memory(self, user_id: str, memory_id: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "DELETE FROM user_memories WHERE id = $2 AND user_id = $1 RETURNING id",
+                uuid.UUID(user_id),
+                uuid.UUID(memory_id),
+            )
+        return row is not None
+
+    async def clear_memories(self, user_id: str) -> int:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM user_memories WHERE user_id = $1", uuid.UUID(user_id)
+            )
+        # asyncpg returns e.g. "DELETE 5"
+        try:
+            return int(result.split()[-1])
+        except (ValueError, IndexError):
+            return 0
+
+
+_store_instance: Optional[UserMemoryStore] = None
+
+
+def get_user_memory_store() -> UserMemoryStore:
+    """Get the process-wide UserMemoryStore singleton."""
+    global _store_instance
+    if _store_instance is None:
+        _store_instance = UserMemoryStore()
+    return _store_instance
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_user_memory_store.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/backend/user_memory_store.py tests/test_user_memory_store.py
+uv run ty check app/backend
+git add app/backend/user_memory_store.py tests/test_user_memory_store.py
+git commit -m "feat: add user-scoped memory store (Postgres)"
+```
+
+---
+
+### Task 2: Memory service — block formatting + op parsing
+
+**Files:**
+- Create: `app/services/user_memory_service.py`
+- Test: `tests/test_user_memory_service.py`
+
+**Interfaces:**
+- Consumes: `UserMemoryRecord` / `UserMemoryStore` from Task 1.
+- Produces:
+  - `build_memory_block(memories: List[Any]) -> str` — accepts objects with `.content`; returns `""` when list is empty, else the block below.
+  - `parse_memory_ops(raw: str) -> List[dict]` — pure; valid ops are `{"op": "add", "content": str}`, `{"op": "update", "id": str, "content": str}`, `{"op": "delete", "id": str}`; malformed input → `[]`; max 3 ops.
+  - `MAX_MEMORY_OPS_PER_TURN = 3`, `MEMORY_EXTRACTION_TIMEOUT_SECONDS = 15`, `MAX_MEMORY_CONTENT_LENGTH = 500`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for user_memory_service pure functions."""
+
+import pytest
+
+from app.services.user_memory_service import (
+    MAX_MEMORY_OPS_PER_TURN,
+    build_memory_block,
+    parse_memory_ops,
+)
+
+
+class FakeMemory:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_build_memory_block_empty():
+    assert build_memory_block([]) == ""
+
+
+def test_build_memory_block_formats_facts():
+    block = build_memory_block([FakeMemory("Prefers concise answers"), FakeMemory("Name is Alex")])
+    assert block.startswith("About the user (persistent memory; use when relevant):")
+    assert "- Prefers concise answers" in block
+    assert "- Name is Alex" in block
+
+
+def test_parse_memory_ops_valid_json():
+    raw = '[{"op": "add", "content": "Likes Rust"}]'
+    assert parse_memory_ops(raw) == [{"op": "add", "content": "Likes Rust"}]
+
+
+def test_parse_memory_ops_strips_code_fence():
+    raw = '```json\n[{"op": "delete", "id": "abc"}]\n```'
+    assert parse_memory_ops(raw) == [{"op": "delete", "id": "abc"}]
+
+
+def test_parse_memory_ops_invalid_json_returns_empty():
+    assert parse_memory_ops("not json at all") == []
+    assert parse_memory_ops("") == []
+
+
+def test_parse_memory_ops_rejects_bad_shapes():
+    raw = """
+    [
+      {"op": "add"},
+      {"op": "add", "content": ""},
+      {"op": "bogus", "content": "x"},
+      {"op": "update", "content": "no id"},
+      {"op": "delete", "id": 42},
+      {"op": "add", "content": 7},
+      "just a string",
+      {"op": "add", "content": "Valid one"}
+    ]
+    """
+    assert parse_memory_ops(raw) == [{"op": "add", "content": "Valid one"}]
+
+
+def test_parse_memory_ops_caps_at_three():
+    raw = "[" + ",".join(f'{{"op": "add", "content": "c{i}"}}' for i in range(10)) + "]"
+    assert len(parse_memory_ops(raw)) == MAX_MEMORY_OPS_PER_TURN
+
+
+def test_parse_memory_ops_truncates_overlong_content():
+    raw = '[{"op": "add", "content": "' + "x" * 600 + '"}]'
+    ops = parse_memory_ops(raw)
+    assert len(ops[0]["content"]) == 500
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_user_memory_service.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the pure functions**
+
+```python
+"""
+User-level persistent memory: prompt-block formatting, extraction-op parsing,
+extraction via the LLM gateway, and the fire-and-forget update orchestration.
+
+All LLM work goes through ``app.services.llm_gateway`` using the request's own
+backend/model config, so behavior is identical on Ollama, OpenRouter, and
+Nvidia NIM. Extraction failures are logged and skipped — they never affect the
+user-visible response.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from app.services.llm_gateway import complete_text
+
+logger = logging.getLogger(__name__)
+
+MAX_MEMORY_OPS_PER_TURN = 3
+MEMORY_EXTRACTION_TIMEOUT_SECONDS = 15
+MAX_MEMORY_CONTENT_LENGTH = 500
+
+MEMORY_BLOCK_HEADER = "About the user (persistent memory; use when relevant):"
+
+
+def build_memory_block(memories: List[Any]) -> str:
+    """Format memory records into a system-prompt block ("" when none)."""
+    contents = [getattr(m, "content", "") for m in memories if getattr(m, "content", "")]
+    if not contents:
+        return ""
+    lines = [MEMORY_BLOCK_HEADER] + [f"- {c}" for c in contents]
+    return "\n".join(lines)
+
+
+def _valid_op(item: Any) -> Optional[Dict[str, Any]]:
+    """Return a normalized op dict, or None if the item is malformed."""
+    if not isinstance(item, dict):
+        return None
+    op = item.get("op")
+    if op == "add":
+        content = item.get("content")
+        if isinstance(content, str) and content.strip():
+            return {"op": "add", "content": content.strip()[:MAX_MEMORY_CONTENT_LENGTH]}
+        return None
+    if op in ("update", "delete"):
+        memory_id = item.get("id")
+        if not isinstance(memory_id, str) or not memory_id:
+            return None
+        if op == "delete":
+            return {"op": "delete", "id": memory_id}
+        content = item.get("content")
+        if isinstance(content, str) and content.strip():
+            return {"op": "update", "id": memory_id, "content": content.strip()[:MAX_MEMORY_CONTENT_LENGTH]}
+        return None
+    return None
+
+
+def parse_memory_ops(raw: str) -> List[Dict[str, Any]]:
+    """Parse the extraction LLM's output into validated ops (max 3)."""
+    if not raw or not raw.strip():
+        return []
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        logger.debug("Memory extraction returned non-JSON output, skipping")
+        return []
+    if not isinstance(data, list):
+        return []
+    ops = []
+    for item in data:
+        op = _valid_op(item)
+        if op is not None:
+            ops.append(op)
+        if len(ops) >= MAX_MEMORY_OPS_PER_TURN:
+            break
+    return ops
+```
+
+Note: `text.strip("`")` also strips backticks inside the fence marker — acceptable because the input is model output that either is a fenced block or raw JSON; the JSON parse afterwards is the real validator.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_user_memory_service.py -v`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/services/user_memory_service.py tests/test_user_memory_service.py
+uv run ty check app/services
+git add app/services/user_memory_service.py tests/test_user_memory_service.py
+git commit -m "feat: memory block formatting and extraction op parsing"
+```
+
+---
+
+### Task 3: Extraction + orchestration (gateway-backed)
+
+**Files:**
+- Modify: `app/services/user_memory_service.py` (append)
+- Test: `tests/test_user_memory_service.py` (append)
+
+**Interfaces:**
+- Consumes: `complete_text(messages, **kwargs) -> str` from `app.services.llm_gateway` (streams internally, returns full text); `parse_memory_ops`, `build_memory_block` from Task 2; `get_user_memory_store()` from Task 1.
+- Produces:
+  - `async def extract_memory_ops(user_message: str, assistant_message: str, existing: List[Any], *, backend=None, model=None, api_base=None, api_key=None) -> List[dict]` — validated ops (may be `[]`); raises nothing (returns `[]` on timeout/error).
+  - `async def apply_memory_ops(store, user_id: str, ops: List[dict]) -> None`.
+  - `async def run_memory_update(user_id: str, user_message: str, assistant_message: str, *, backend=None, model=None, api_base=None, api_key=None) -> None` — full pipeline, swallows all exceptions (fire-and-forget safe).
+  - `async def load_memory_block(user_id: Optional[str]) -> str` — store read + `build_memory_block`; `""` on any failure or when `user_id` is None.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# ── Extraction and orchestration (Task 3) ──────────────────────────────────
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import app.services.user_memory_service as ums
+from app.services.user_memory_service import (
+    apply_memory_ops,
+    extract_memory_ops,
+    load_memory_block,
+    run_memory_update,
+)
+
+
+class FakeStore:
+    def __init__(self, memories=None):
+        self.memories = list(memories or [])
+        self.added = []
+        self.updated = []
+        self.deleted = []
+
+    async def list_memories(self, user_id, limit=50):
+        return self.memories
+
+    async def add_memory(self, user_id, content, source="auto"):
+        self.added.append((user_id, content, source))
+
+        class R:
+            content = content
+
+        return R()
+
+    async def update_memory(self, user_id, memory_id, content):
+        self.updated.append((user_id, memory_id, content))
+        return True
+
+    async def delete_memory(self, user_id, memory_id):
+        self.deleted.append((user_id, memory_id))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_extract_memory_ops_sends_prompt_and_parses():
+    with patch.object(ums, "complete_text", new=AsyncMock(return_value='[{"op": "add", "content": "Owns a dog"}]')) as mock_llm:
+        ops = await extract_memory_ops("I own a dog named Rex", "That's lovely!", [], backend="ollama", model="gemma3:1b")
+    assert ops == [{"op": "add", "content": "Owns a dog"}]
+    sent = mock_llm.call_args.args[0]
+    assert any(m["role"] == "system" for m in sent)
+    assert "I own a dog named Rex" in sent[-1]["content"]
+    assert mock_llm.call_args.kwargs["backend"] == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_extract_memory_ops_returns_empty_on_llm_error():
+    with patch.object(ums, "complete_text", new=AsyncMock(side_effect=RuntimeError("provider down"))):
+        assert await extract_memory_ops("hi", "hello", []) == []
+
+
+@pytest.mark.asyncio
+async def test_apply_memory_ops_dispatches_to_store():
+    store = FakeStore()
+    await apply_memory_ops(
+        store, "user-1",
+        [
+            {"op": "add", "content": "New fact"},
+            {"op": "update", "id": "m1", "content": "Edited"},
+            {"op": "delete", "id": "m2"},
+        ],
+    )
+    assert store.added == [("user-1", "New fact", "auto")]
+    assert store.updated == [("user-1", "m1", "Edited")]
+    assert store.deleted == [("user-1", "m2")]
+
+
+@pytest.mark.asyncio
+async def test_run_memory_update_swallows_all_errors():
+    with patch.object(ums, "get_user_memory_store", side_effect=RuntimeError("db down")):
+        await run_memory_update("user-1", "hi", "hello")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_run_memory_update_happy_path():
+    store = FakeStore(memories=[])
+    with patch.object(ums, "get_user_memory_store", return_value=store), \
+         patch.object(ums, "complete_text", new=AsyncMock(return_value='[{"op": "add", "content": "Lives in Berlin"}]')):
+        await run_memory_update("user-1", "I live in Berlin", "Nice city!")
+    assert store.added == [("user-1", "Lives in Berlin", "auto")]
+
+
+@pytest.mark.asyncio
+async def test_load_memory_block_empty_user():
+    assert await load_memory_block(None) == ""
+
+
+@pytest.mark.asyncio
+async def test_load_memory_block_degrades_on_store_error():
+    with patch.object(ums, "get_user_memory_store", side_effect=RuntimeError("db down")):
+        assert await load_memory_block("user-1") == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_user_memory_service.py -v`
+Expected: FAIL — `ImportError: cannot import name 'extract_memory_ops'`
+
+- [ ] **Step 3: Implement extraction and orchestration**
+
+Append to `app/services/user_memory_service.py`:
+
+```python
+_EXTRACTION_SYSTEM_PROMPT = """You maintain long-term memory for a personal assistant. \
+Given a conversation exchange and the user's existing memories, decide what durable facts about the \
+user should be stored, updated, or removed.
+
+Return ONLY a JSON array. Each element is exactly one of:
+{"op": "add", "content": "<new memory, one concise sentence>"}
+{"op": "update", "id": "<existing memory id>", "content": "<corrected memory>"}
+{"op": "delete", "id": "<existing memory id that is now wrong or obsolete>"}
+
+Rules:
+- Store only durable facts: the user's identity, stable preferences, ongoing projects or goals, \
+corrections to existing memories, and explicit requests to remember something.
+- Never store secrets, credentials, API keys, passwords, or transient task details.
+- Prefer updating an existing memory over adding a near-duplicate.
+- At most 3 operations. Return [] when nothing durable was shared."""
+
+
+def _build_extraction_messages(
+    user_message: str, assistant_message: str, existing: List[Any]
+) -> List[Dict[str, str]]:
+    existing_lines = "\n".join(
+        f'- id={getattr(m, "id", "?")}: {getattr(m, "content", "")}' for m in existing
+    )
+    return [
+        {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": (
+                f"Existing memories:\n{existing_lines or '(none)'}\n\n"
+                f"User said:\n{user_message}\n\n"
+                f"Assistant replied:\n{assistant_message}"
+            ),
+        },
+    ]
+
+
+async def extract_memory_ops(
+    user_message: str,
+    assistant_message: str,
+    existing: List[Any],
+    *,
+    backend: Optional[str] = None,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Ask the LLM which memories to add/update/delete; [] on any failure."""
+    if not user_message.strip():
+        return []
+    messages = _build_extraction_messages(user_message, assistant_message, existing)
+    try:
+        raw = await asyncio.wait_for(
+            complete_text(
+                messages,
+                backend=backend,
+                model=model,
+                api_base=api_base,
+                api_key=api_key,
+                max_tokens=300,
+            ),
+            timeout=MEMORY_EXTRACTION_TIMEOUT_SECONDS,
+        )
+    except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001 — extraction must never raise
+        logger.warning("Memory extraction failed/skipped: %s", exc)
+        return []
+    return parse_memory_ops(raw)
+
+
+async def apply_memory_ops(store: Any, user_id: str, ops: List[Dict[str, Any]]) -> None:
+    """Apply validated ops to the store; unknown ids are ignored by the store."""
+    for op in ops:
+        if op["op"] == "add":
+            await store.add_memory(user_id, op["content"], source="auto")
+        elif op["op"] == "update":
+            await store.update_memory(user_id, op["id"], op["content"])
+        elif op["op"] == "delete":
+            await store.delete_memory(user_id, op["id"])
+
+
+async def run_memory_update(
+    user_id: str,
+    user_message: str,
+    assistant_message: str,
+    *,
+    backend: Optional[str] = None,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> None:
+    """Extract and apply memory ops for one completed exchange. Never raises."""
+    try:
+        store = get_user_memory_store()
+        existing = await store.list_memories(user_id)
+        ops = await extract_memory_ops(
+            user_message,
+            assistant_message,
+            existing,
+            backend=backend,
+            model=model,
+            api_base=api_base,
+            api_key=api_key,
+        )
+        await apply_memory_ops(store, user_id, ops)
+        if ops:
+            logger.info("User memory updated for user %s (%d ops)", user_id, len(ops))
+    except Exception as exc:  # noqa: BLE001 — fire-and-forget task must be self-contained
+        logger.warning("User memory update failed for user %s: %s", user_id, exc)
+
+
+async def load_memory_block(user_id: Optional[str]) -> str:
+    """Load and format the user's memories for prompt injection ("" on failure)."""
+    if not user_id:
+        return ""
+    try:
+        store = get_user_memory_store()
+        memories = await store.list_memories(user_id)
+        return build_memory_block(memories)
+    except Exception as exc:  # noqa: BLE001 — degraded response beats failed response
+        logger.warning("Failed to load user memory for user %s: %s", user_id, exc)
+        return ""
+```
+
+Add this import at the top of the file (merge with existing imports):
+
+```python
+from app.backend.user_memory_store import get_user_memory_store
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_user_memory_service.py -v`
+Expected: PASS (15 tests)
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/services/user_memory_service.py tests/test_user_memory_service.py
+uv run ty check app/services
+git add app/services/user_memory_service.py tests/test_user_memory_service.py
+git commit -m "feat: LLM-backed memory extraction and fire-and-forget update"
+```
+
+---
+
+### Task 4: `/api/memory` CRUD router
+
+**Files:**
+- Modify: `app/backend/models/api_models.py` (append models)
+- Create: `app/backend/api/memory.py`
+- Modify: `main.py` (router registration — after `app.include_router(voice_api.router)`, around `main.py:343`)
+- Test: `tests/test_memory_api.py`
+
+**Interfaces:**
+- Consumes: `get_current_user`/`User` from `app.backend.api.auth_deps`; `get_user_memory_store` from Task 1; store methods from Task 1.
+- Produces: routes `GET /api/memory`, `POST /api/memory` (body `{"content": str}` → source `"manual"`), `PUT /api/memory/{memory_id}` (body `{"content": str}`), `DELETE /api/memory/{memory_id}`, `POST /api/memory/clear`. Pydantic models `MemoryContentRequest(content: str)`, `MemoryRecordResponse(id: str, content: str, source: str, created_at: str, updated_at: str)` in `api_models.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""API tests for /api/memory — auth required, user-scoped CRUD."""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class FakeStore:
+    def __init__(self):
+        self.rows = {}
+
+    async def list_memories(self, user_id, limit=50):
+        return [r for r in self.rows.values() if r.user_id == user_id]
+
+    async def add_memory(self, user_id, content, source="auto"):
+        from app.backend.user_memory_store import UserMemoryRecord
+
+        rec = UserMemoryRecord(
+            id=str(uuid.uuid4()), user_id=user_id, content=content, source=source,
+            created_at="2026-08-23T00:00:00", updated_at="2026-08-23T00:00:00",
+        )
+        self.rows[rec.id] = rec
+        return rec
+
+    async def update_memory(self, user_id, memory_id, content):
+        r = self.rows.get(memory_id)
+        if not r or r.user_id != user_id:
+            return False
+        r.content = content
+        return True
+
+    async def delete_memory(self, user_id, memory_id):
+        r = self.rows.get(memory_id)
+        if not r or r.user_id != user_id:
+            return False
+        del self.rows[memory_id]
+        return True
+
+    async def clear_memories(self, user_id):
+        ids = [i for i, r in self.rows.items() if r.user_id == user_id]
+        for i in ids:
+            del self.rows[i]
+        return len(ids)
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    from fastapi.testclient import TestClient
+    from main import app
+    import app.backend.api.memory as memory_api
+    from app.backend.api.auth_deps import User, get_current_user
+
+    store = FakeStore()
+    # Router resolves the singleton via its own module namespace at call time,
+    # so patching memory_api.get_user_memory_store intercepts every endpoint.
+    monkeypatch.setattr(memory_api, "get_user_memory_store", lambda: store)
+    # Same override pattern as tests/test_chat_auth.py:_make_app
+    app.dependency_overrides[get_current_user] = lambda: User(
+        id=str(uuid.uuid4()), email="u1@x.com"
+    )
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_memory_requires_auth():
+    from fastapi.testclient import TestClient
+    from main import app
+
+    with TestClient(app) as c:
+        assert c.get("/api/memory").status_code == 401
+
+
+def test_memory_crud_roundtrip(client):
+    resp = client.post("/api/memory", json={"content": "Prefers dark mode"})
+    assert resp.status_code == 200
+    mid = resp.json()["id"]
+    assert resp.json()["source"] == "manual"
+
+    listed = client.get("/api/memory").json()
+    assert [m["content"] for m in listed] == ["Prefers dark mode"]
+
+    assert client.put(f"/api/memory/{mid}", json={"content": "Prefers light mode"}).status_code == 200
+    assert client.get("/api/memory").json()[0]["content"] == "Prefers light mode"
+
+    assert client.delete(f"/api/memory/{mid}").status_code == 200
+    assert client.get("/api/memory").json() == []
+
+
+def test_memory_add_rejects_blank_content(client):
+    assert client.post("/api/memory", json={"content": "   "}).status_code == 422
+
+
+def test_memory_update_unknown_id_404(client):
+    assert client.put(f"/api/memory/{uuid.uuid4()}", json={"content": "x"}).status_code == 404
+
+
+def test_memory_clear(client):
+    client.post("/api/memory", json={"content": "a"})
+    client.post("/api/memory", json={"content": "b"})
+    resp = client.post("/api/memory/clear")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 2
+    assert client.get("/api/memory").json() == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_memory_api.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.backend.api.memory'`
+
+- [ ] **Step 3: Add models, router, registration**
+
+Append to `app/backend/models/api_models.py`:
+
+```python
+class MemoryContentRequest(BaseModel):
+    content: str = Field(..., min_length=1, description="Memory text (trimmed server-side)")
+
+
+class MemoryRecordResponse(BaseModel):
+    id: str
+    content: str
+    source: str
+    created_at: str
+    updated_at: str
+```
+
+(If `Field` is not yet imported in that file, add it to the existing `pydantic` import.)
+
+Create `app/backend/api/memory.py`:
+
+```python
+"""User-level persistent memory CRUD endpoints (all require authentication)."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.backend.api.auth_deps import User, get_current_user
+from app.backend.models.api_models import MemoryContentRequest, MemoryRecordResponse
+from app.backend.user_memory_store import get_user_memory_store
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/memory", tags=["memory"])
+
+
+def _response(record) -> MemoryRecordResponse:
+    return MemoryRecordResponse(
+        id=record.id,
+        content=record.content,
+        source=record.source,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+@router.get("", response_model=list[MemoryRecordResponse])
+async def list_memories(user: User = Depends(get_current_user)):
+    records = await get_user_memory_store().list_memories(user.id)
+    return [_response(r) for r in records]
+
+
+@router.post("", response_model=MemoryRecordResponse)
+async def add_memory(request: MemoryContentRequest, user: User = Depends(get_current_user)):
+    content = request.content.strip()
+    if not content:
+        raise HTTPException(status_code=422, detail="Memory content cannot be empty")
+    record = await get_user_memory_store().add_memory(user.id, content, source="manual")
+    return _response(record)
+
+
+@router.put("/{memory_id}")
+async def update_memory(memory_id: str, request: MemoryContentRequest, user: User = Depends(get_current_user)):
+    content = request.content.strip()
+    if not content:
+        raise HTTPException(status_code=422, detail="Memory content cannot be empty")
+    updated = await get_user_memory_store().update_memory(user.id, memory_id, content)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"status": "updated", "id": memory_id}
+
+
+@router.delete("/{memory_id}")
+async def delete_memory(memory_id: str, user: User = Depends(get_current_user)):
+    deleted = await get_user_memory_store().delete_memory(user.id, memory_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Memory not found")
+    return {"status": "deleted", "id": memory_id}
+
+
+@router.post("/clear")
+async def clear_memories(user: User = Depends(get_current_user)):
+    count = await get_user_memory_store().clear_memories(user.id)
+    return {"status": "cleared", "deleted": count}
+```
+
+In `main.py`, add the import next to the other API imports (around `main.py:27-30`):
+
+```python
+from app.backend.api import memory as memory_api
+```
+
+and register after `app.include_router(voice_api.router)` (`main.py:343`):
+
+```python
+app.include_router(memory_api.router)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_memory_api.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/backend/api/memory.py main.py tests/test_memory_api.py
+uv run ty check app/backend main.py
+git add app/backend/api/memory.py app/backend/models/api_models.py main.py tests/test_memory_api.py
+git commit -m "feat: /api/memory CRUD endpoints"
+```
+
+---
+
+### Task 5: Chat injection + extraction triggers
+
+**Files:**
+- Modify: `app/backend/api/chat.py` — `_build_messages_with_history` (line 159), `_handle_chat_request` (278), `_stream_chat_response` (311), `chat_endpoint` (246), `chat_stream` (259)
+- Test: `tests/test_user_memory_wiring.py`
+
+**Interfaces:**
+- Consumes: `load_memory_block(user_id) -> str`, `run_memory_update(user_id, user_message, assistant_message, *, backend, model, api_base, api_key)` from Task 3.
+- Produces: `_build_messages_with_history(request, memory_block: Optional[str] = None) -> List[Dict[str, str]]`; `_handle_chat_request(request, user_id: Optional[str] = None)`; `_stream_chat_response(request, user_id: Optional[str] = None)`. All chat routes pass `user.id`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Chat wiring: memory block injection + post-exchange extraction trigger."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.backend.api.chat as chat_api
+from app.backend.models.api_models import ChatMessage, ChatRequestEnhanced
+
+
+def _request(**overrides):
+    base = dict(message="Remember I like tea", backend="ollama", model="gemma3:1b")
+    base.update(overrides)
+    return ChatRequestEnhanced(**base)
+
+
+@pytest.mark.asyncio
+async def test_stream_injects_memory_block():
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="About the user:\n- Likes tea")), \
+         patch.object(chat_api, "stream_completion", new=AsyncMock(return_value=aiter(["Hello"]))):
+        chunks = [c async for c in chat_api._stream_chat_response(_request(), user_id="u-1")]
+    assert chunks == ["Hello"]
+    sent = chat_api.stream_completion.call_args.args[0]
+    assert sent[0] == {"role": "system", "content": "About the user:\n- Likes tea"}
+
+
+@pytest.mark.asyncio
+async def test_stream_skips_block_when_empty():
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="")), \
+         patch.object(chat_api, "stream_completion", new=AsyncMock(return_value=aiter(["Hi"]))):
+        await anext(chat_api._stream_chat_response(_request(), user_id="u-1"))
+    sent = chat_api.stream_completion.call_args.args[0]
+    assert sent[0]["role"] != "system" or "persistent memory" not in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_non_stream_path_triggers_extraction():
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="")), \
+         patch.object(chat_api, "complete_text", new=AsyncMock(return_value="Enjoy your tea!")), \
+         patch.object(chat_api.asyncio, "create_task") as mock_task, \
+         patch.object(chat_api, "run_memory_update", new=AsyncMock()):
+        await chat_api._handle_chat_request(_request(), user_id="u-1")
+    assert mock_task.called
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_request_without_user_skips_memory_load():
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="")) as mock_load, \
+         patch.object(chat_api, "complete_text", new=AsyncMock(return_value="ok")):
+        await chat_api._handle_chat_request(_request())
+    mock_load.assert_not_called()
+
+
+async def aiter(items):
+    for i in items:
+        yield i
+```
+
+**Note:** if `test_chat_auth.py` already patches gateway functions differently (e.g. patching `stream_completion` on the gateway module), match its existing patch targets so both suites stay green — read `tests/test_chat_auth.py` before finalizing the mocks above.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_user_memory_wiring.py -v`
+Expected: FAIL — `_stream_chat_response() got an unexpected keyword argument 'user_id'`
+
+- [ ] **Step 3: Implement the wiring**
+
+In `app/backend/api/chat.py`:
+
+Add imports near the top:
+
+```python
+from app.services.user_memory_service import load_memory_block, run_memory_update
+```
+
+Change `_build_messages_with_history` signature and prepend the block (keep the rest of the function identical):
+
+```python
+def _build_messages_with_history(
+    request: ChatRequestEnhanced, memory_block: Optional[str] = None
+) -> List[Dict[str, str]]:
+    """
+    Build the messages list including conversation history and summary.
+    Also applies voice mode optimizations if is_voice_mode is True.
+
+    Args:
+        request: The chat request with optional history/summary
+        memory_block: Pre-formatted persistent user-memory block (may be empty)
+
+    Returns:
+        List of messages ready for LLM
+    """
+    messages = []
+
+    # Persistent user memory comes first so later system prompts can refine it
+    if memory_block:
+        messages.append({"role": "system", "content": memory_block})
+
+    # Add voice mode system prompt if voice mode is active
+    if request.is_voice_mode:
+        ...  # existing body unchanged from here down
+```
+
+Change the two callers to load and pass the block:
+
+```python
+async def _handle_chat_request(request: ChatRequestEnhanced, user_id: Optional[str] = None) -> ChatResponse:
+    """Handle a chat request with conversation history."""
+    memory_block = await load_memory_block(user_id) if user_id else ""
+    messages = _build_messages_with_history(request, memory_block=memory_block)
+    # ... existing body unchanged ...
+    return ChatResponse(response=response_text, model=request.model if request.model is not None else "default")
+```
+
+```python
+async def _stream_chat_response(request: ChatRequestEnhanced, user_id: Optional[str] = None):
+    """Stream chat responses with conversation history."""
+    memory_block = await load_memory_block(user_id) if user_id else ""
+    messages = _build_messages_with_history(request, memory_block=memory_block)
+    # ... existing body unchanged ...
+```
+
+Update `chat_endpoint` to trigger extraction after a successful response:
+
+```python
+@router.post("/api/chat", response_model=ChatResponse)
+async def chat_endpoint(request: ChatRequestEnhanced, user: User = Depends(get_current_user)):
+    """Single chat message processing (requires authentication)."""
+    logger.info(f"Chat request - User: {user.id}, Backend: {request.backend}, Model: {request.model}")
+
+    try:
+        response = await _handle_chat_request(request, user_id=user.id)
+        asyncio.create_task(
+            run_memory_update(
+                user.id,
+                request.message,
+                response.response,
+                backend=request.backend,
+                model=request.model,
+                api_base=request.api_base,
+                api_key=request.api_key,
+            )
+        )
+        return response
+
+    except Exception:
+        logger.exception("Chat endpoint error")
+        raise HTTPException(status_code=500, detail="An internal error occurred")
+```
+
+Update `chat_stream` to accumulate and trigger after a clean stream:
+
+```python
+@router.post("/api/chat/stream")
+async def chat_stream(request: ChatRequestEnhanced, user: User = Depends(get_current_user)):
+    """Stream chat responses (requires authentication)."""
+    logger.info(f"Streaming chat - User: {user.id}, Backend: {request.backend}, Model: {request.model}")
+
+    async def event_generator():
+        collected: List[str] = []
+        try:
+            async for chunk in _stream_chat_response(request, user_id=user.id):
+                collected.append(chunk)
+                payload = json.dumps({"chunk": chunk}, ensure_ascii=False)
+                yield f"data: {payload}\n\n"
+
+            if collected:
+                asyncio.create_task(
+                    run_memory_update(
+                        user.id,
+                        request.message,
+                        "".join(collected),
+                        backend=request.backend,
+                        model=request.model,
+                        api_base=request.api_base,
+                        api_key=request.api_key,
+                    )
+                )
+
+        except Exception:
+            logger.exception("Chat streaming error")
+            payload = json.dumps({"error": "An internal error occurred"}, ensure_ascii=False)
+            yield f"data: {payload}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+```
+
+(Extraction is intentionally skipped when the stream errors — partial exchanges produce noisy memories.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_user_memory_wiring.py tests/test_chat_auth.py -v`
+Expected: PASS — new tests and existing chat auth tests
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/backend/api/chat.py tests/test_user_memory_wiring.py
+uv run ty check app/backend
+git add app/backend/api/chat.py tests/test_user_memory_wiring.py
+git commit -m "feat: inject user memory into chat and extract after exchanges"
+```
+
+---
+
+### Task 6: RAG injection
+
+**Files:**
+- Modify: `app/services/rag_service.py` — `query(...)` (starts `app/services/rag_service.py:1543`; message assembly at ~1615-1652)
+- Modify: `app/skills/rag.py` — both skills' `stream()` (StandardRAGSkill at `app/skills/rag.py:26-52`, MultiAgentRAGSkill at `app/skills/rag.py:66-95`)
+- Modify: `main.py` — `rag_query` (`main.py:765-785`)
+- Test: `tests/test_user_memory_wiring.py` (append)
+
+**Interfaces:**
+- Consumes: `load_memory_block` from Task 3; `rag_skill_registry` skills' `stream(request, rag_service)` protocol (extended additively with a default-valued third parameter).
+- Produces: `StandardRAGSkill.stream(request, rag_service, memory_block: Optional[str] = None)`; `MultiAgentRAGSkill.stream(..., memory_block=None)` (forwards to fallback skill; multi-agent orchestrator path ignores it — CrewAI path unchanged); `rag_service.query(..., memory_block: Optional[str] = None)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_user_memory_wiring.py`:
+
+```python
+# ── RAG injection ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_rag_query_injects_memory_block():
+    """query(..., memory_block=...) must place the block before conversation history."""
+    from app.services import rag_service as rag_module
+    from app.services.rag_service import RAGService
+
+    svc = RAGService.__new__(RAGService)  # retrieval + prompt seams are patched below
+
+    block = {"role": "system", "content": "About the user:\n- Likes tea"}
+    with patch.object(svc, "get_retrieval_records", return_value=[]), \
+         patch.object(svc, "build_grounded_user_prompt", return_value="grounded"), \
+         patch.object(rag_module, "stream_completion", new=AsyncMock(return_value=aiter(["answer"]))):
+        chunks = [
+            c
+            async for c in svc.query(
+                "what is x",
+                system_prompt="You are helpful.",
+                messages=[{"role": "user", "content": "hi"}],
+                memory_block="About the user:\n- Likes tea",
+            )
+        ]
+
+    assert "answer" in chunks
+    sent = rag_module.stream_completion.call_args.args[0]
+    assert block in sent
+    assert sent.index(block) < sent.index({"role": "user", "content": "hi"})
+```
+
+**Verified seams** (`app/services/rag_service.py`, `query()` body): retrieval goes through `self.get_retrieval_records(full_query, n_results, use_hybrid_search)` (~line 1588); the final LLM call is the module-level `stream_completion(llm_messages, ...)` imported at line 25 — hence the `rag_module.stream_completion` patch target. The empty-retrieval path is safe: score normalization handles `[]`, and a citations JSON line is yielded before the answer chunks.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_user_memory_wiring.py -v`
+Expected: FAIL — `query() got an unexpected keyword argument 'memory_block'`
+
+- [ ] **Step 3: Implement**
+
+In `app/services/rag_service.py`, add the parameter to `query(...)` (after `is_voice_mode: bool = False,`):
+
+```python
+            memory_block: Optional[str] = None,
+```
+
+and inject it in the message assembly (immediately after the conversation-summary append at ~1617-1621):
+
+```python
+            # Persistent user memory (may be empty)
+            if memory_block:
+                llm_messages.append({"role": "system", "content": memory_block})
+```
+
+In `app/skills/rag.py`, change both signatures and forwarding:
+
+```python
+    async def stream(
+        self, request: Any, rag_service: Any, memory_block: Optional[str] = None
+    ) -> AsyncIterator[str]:
+        async for chunk in rag_service.query(
+            request.query,
+            request.system_prompt,
+            _rag_messages(request),
+            request.n_results,
+            request.use_hybrid_search,
+            request.model,
+            conversation_summary=request.conversation_summary,
+            memory_block=memory_block,
+            backend=request.backend,
+            # ... remaining kwargs unchanged ...
+        ):
+            yield chunk
+```
+
+(Add `from typing import Optional` to the imports if absent.)
+
+For `MultiAgentRAGSkill.stream`, add the same `memory_block: Optional[str] = None` parameter and forward it in **both** fallback calls:
+
+```python
+            async for chunk in self._fallback_skill.stream(request, rag_service, memory_block=memory_block):
+                yield chunk
+```
+
+(The CrewAI `orchestrator.query(...)` call stays unchanged — multi-agent mode does not inject memory v1.)
+
+In `main.py` `rag_query` (`main.py:765`), load the block and pass it through:
+
+```python
+@app.post("/api/rag/query")
+async def rag_query(request: RAGQueryRequestEnhanced, user: User = Depends(get_current_user)):
+    """Query RAG system (requires authentication)."""
+    try:
+        if not rag_service:
+            raise HTTPException(status_code=503, detail="RAG service not initialized")
+
+        skill = rag_skill_registry.resolve(request)
+        if skill is None:
+            raise HTTPException(status_code=400, detail="No compatible RAG skill found for request")
+
+        from app.services.user_memory_service import load_memory_block
+
+        memory_block = await load_memory_block(user.id)
+
+        async def event_generator():
+            logger.info("Routing RAG query through skill '%s'", skill.name)
+            async for chunk in skill.stream(request, rag_service, memory_block=memory_block):
+                yield chunk + "\n"
+
+        return StreamingResponse(event_generator(), media_type="text/plain")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"RAG query error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_user_memory_wiring.py tests/test_rag_skills.py -v`
+Expected: PASS — new test and existing RAG skill tests
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/services/rag_service.py app/skills/rag.py main.py tests/test_user_memory_wiring.py
+uv run ty check app/services app/skills main.py
+git add app/services/rag_service.py app/skills/rag.py main.py tests/test_user_memory_wiring.py
+git commit -m "feat: inject user memory into RAG answers"
+```
+
+---
+
+### Task 7: Voice pipeline injection + per-turn extraction
+
+**Files:**
+- Modify: `app/services/voice_pipeline.py` — `build_voice_pipeline` (line 73) and `BackendLLMService._process_context` (line 160)
+- Test: `tests/test_user_memory_wiring.py` (append)
+
+**Interfaces:**
+- Consumes: `VoiceSettings(user_id, system_instruction, backend, model, api_key, api_base)` (already exists); `load_memory_block`, `run_memory_update` from Task 3.
+- Produces: `build_voice_pipeline` becomes aware of memory (still sync-callable? No — it must become `async` if it awaits; check its caller `run_voice_pipeline`/`voice.py` and make it `async def` + await at the call site, or load memories in `run_voice_pipeline` before calling it — prefer loading in `run_voice_pipeline` and passing `memory_block` into `VoiceSettings.system_instruction` mutation to keep `build_voice_pipeline` sync).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_user_memory_wiring.py`:
+
+```python
+# ── Voice pipeline ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_voice_pipeline_prepends_memory_to_system_instruction():
+    from app.services.voice_pipeline import VoiceSettings
+
+    settings = VoiceSettings(user_id="u-1", system_instruction="You are a helpful voice assistant.")
+    with patch("app.services.voice_pipeline.load_memory_block", new=AsyncMock(return_value="About the user:\n- Likes tea")):
+        from app.services.voice_pipeline import apply_memory_to_voice_settings
+
+        await apply_memory_to_voice_settings(settings)
+    assert settings.system_instruction.startswith("You are a helpful voice assistant.")
+    assert "Likes tea" in settings.system_instruction
+
+
+@pytest.mark.asyncio
+async def test_voice_pipeline_skips_memory_without_user():
+    from app.services.voice_pipeline import VoiceSettings, apply_memory_to_voice_settings
+
+    settings = VoiceSettings(user_id=None, system_instruction="base")
+    with patch("app.services.voice_pipeline.load_memory_block", new=AsyncMock(return_value="X")) as m:
+        await apply_memory_to_voice_settings(settings)
+    m.assert_not_called()
+    assert settings.system_instruction == "base"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_user_memory_wiring.py -v`
+Expected: FAIL — `ImportError: cannot import name 'apply_memory_to_voice_settings'`
+
+- [ ] **Step 3: Implement**
+
+In `app/services/voice_pipeline.py`:
+
+Add import:
+
+```python
+from app.services.user_memory_service import load_memory_block, run_memory_update
+```
+
+Add helper next to `VoiceSettings`:
+
+```python
+async def apply_memory_to_voice_settings(settings: VoiceSettings) -> None:
+    """Fold the user's persistent memory into the voice system instruction."""
+    if not settings.user_id:
+        return
+    block = await load_memory_block(settings.user_id)
+    if block:
+        settings.system_instruction = f"{settings.system_instruction}\n\n{block}"
+```
+
+In `run_voice_pipeline` (line 254), before building the pipeline:
+
+```python
+    await apply_memory_to_voice_settings(settings)
+```
+
+In `BackendLLMService._process_context` (line 160), capture the exchange and schedule extraction after the stream completes:
+
+```python
+    async def _process_context(self, context: LLMContext):
+        raw_messages = cast("list[dict[str, Any]]", context.get_messages())
+        messages = [
+            {"role": m.get("role", "user"), "content": m.get("content", "")}
+            for m in raw_messages
+        ]
+        last_user = next(
+            (m["content"] for m in reversed(messages) if m.get("role") == "user"), ""
+        )
+        reply_parts: list[str] = []
+        async for delta in stream_completion(
+            messages,
+            backend=self._voice_settings.backend,
+            model=self._voice_settings.model,
+            api_key=self._voice_settings.api_key,
+            api_base=self._voice_settings.api_base,
+            temperature=self._voice_settings.temperature,
+            max_tokens=self._voice_settings.max_tokens,
+        ):
+            if delta:
+                reply_parts.append(delta)
+                await self.push_frame(LLMTextFrame(text=delta))
+
+        # Fire-and-forget memory extraction for this voice turn
+        if self._voice_settings.user_id and last_user and reply_parts:
+            asyncio.create_task(
+                run_memory_update(
+                    self._voice_settings.user_id,
+                    last_user,
+                    "".join(reply_parts),
+                    backend=self._voice_settings.backend,
+                    model=self._voice_settings.model,
+                    api_base=self._voice_settings.api_base,
+                    api_key=self._voice_settings.api_key,
+                )
+            )
+```
+
+(Add `import asyncio` at the top if absent.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_user_memory_wiring.py tests/test_rag_voice_auth.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check app/services/voice_pipeline.py tests/test_user_memory_wiring.py
+uv run ty check app/services
+git add app/services/voice_pipeline.py tests/test_user_memory_wiring.py
+git commit -m "feat: user memory in voice mode (injection + per-turn extraction)"
+```
+
+---
+
+### Task 8: Frontend — memory API client + Settings panel section
+
+**Files:**
+- Modify: `nextjs-frontend/src/lib/types.ts` (append type)
+- Modify: `nextjs-frontend/src/lib/api.ts` (append client functions)
+- Modify: `nextjs-frontend/src/components/settings-panel.tsx` (add Memory section — follow the existing `Section` component at the top of the file, used at e.g. line 181/407/430)
+- Test: `nextjs-frontend/src/components/memory-settings.test.tsx`
+
+**Interfaces:**
+- Consumes: `/api/memory` endpoints from Task 4; existing `API_BASE`/`credentials: 'include'` fetch pattern in `api.ts`.
+- Produces: `MemoryRecord` type; `getMemories()`, `addMemory(content)`, `updateMemory(id, content)`, `deleteMemory(id)`, `clearMemories()`.
+
+- [ ] **Step 1: Write the failing test**
+
+`nextjs-frontend/src/components/memory-settings.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemorySettings } from './settings-panel';
+import * as api from '@/lib/api';
+
+vi.mock('@/lib/api', () => ({
+  getMemories: vi.fn(),
+  addMemory: vi.fn(),
+  updateMemory: vi.fn(),
+  deleteMemory: vi.fn(),
+  clearMemories: vi.fn(),
+}));
+
+const mem = (id: string, content: string) => ({
+  id, content, source: 'auto', created_at: '2026-08-23T00:00:00', updated_at: '2026-08-23T00:00:00',
+});
+
+describe('MemorySettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getMemories).mockResolvedValue([mem('m1', 'Prefers dark mode')]);
+  });
+
+  it('lists memories on load', async () => {
+    render(<MemorySettings />);
+    expect(await screen.findByText('Prefers dark mode')).toBeInTheDocument();
+  });
+
+  it('adds a memory', async () => {
+    vi.mocked(api.addMemory).mockResolvedValue(mem('m2', 'New fact'));
+    render(<MemorySettings />);
+    await screen.findByText('Prefers dark mode');
+    await userEvent.type(screen.getByPlaceholderText(/add a memory/i), 'New fact');
+    await userEvent.click(screen.getByRole('button', { name: /add/i }));
+    await waitFor(() => expect(api.addMemory).toHaveBeenCalledWith('New fact'));
+    expect(await screen.findByText('New fact')).toBeInTheDocument();
+  });
+
+  it('deletes a memory', async () => {
+    vi.mocked(api.deleteMemory).mockResolvedValue(undefined);
+    render(<MemorySettings />);
+    await screen.findByText('Prefers dark mode');
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => expect(api.deleteMemory).toHaveBeenCalledWith('m1'));
+    expect(screen.queryByText('Prefers dark mode')).not.toBeInTheDocument();
+  });
+});
+```
+
+**Note:** match the exact import alias your project uses for `@/lib/api` (check an existing test, e.g. `store.auth.test.ts`) and the existing testing-library setup; if `userEvent` is not configured in the project, use `fireEvent` from `@testing-library/react` instead.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (in `nextjs-frontend/`): `npx vitest run src/components/memory-settings.test.tsx`
+Expected: FAIL — `MemorySettings` is not exported
+
+- [ ] **Step 3: Implement types, API client, and component**
+
+Append to `nextjs-frontend/src/lib/types.ts`:
+
+```ts
+export interface MemoryRecord {
+  id: string;
+  content: string;
+  source: 'auto' | 'manual';
+  created_at: string;
+  updated_at: string;
+}
+```
+
+Append to `nextjs-frontend/src/lib/api.ts`:
+
+```ts
+// ── User memory (personalization) ──────────────────────────────────────────
+
+export async function getMemories(): Promise<MemoryRecord[]> {
+  const res = await fetch(`${API_BASE}/api/memory`, { credentials: 'include', cache: 'no-store' });
+  if (!res.ok) throw new Error(`Failed to load memories: ${res.status}`);
+  return res.json();
+}
+
+export async function addMemory(content: string): Promise<MemoryRecord> {
+  const res = await fetch(`${API_BASE}/api/memory`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error(`Failed to add memory: ${res.status}`);
+  return res.json();
+}
+
+export async function updateMemory(id: string, content: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/memory/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error(`Failed to update memory: ${res.status}`);
+}
+
+export async function deleteMemory(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/memory/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Failed to delete memory: ${res.status}`);
+}
+
+export async function clearMemories(): Promise<{ deleted: number }> {
+  const res = await fetch(`${API_BASE}/api/memory/clear`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Failed to clear memories: ${res.status}`);
+  return res.json();
+}
+```
+
+(Add `MemoryRecord` to the existing type imports at the top of `api.ts`.)
+
+In `nextjs-frontend/src/components/settings-panel.tsx`, add a `MemorySettings` component and render it as a new `<Section title="Memory">` after the existing "Knowledge Base" section (line ~492):
+
+```tsx
+function MemorySettings() {
+  const [memories, setMemories] = useState<MemoryRecord[]>([]);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setMemories(await getMemories());
+      setError(null);
+    } catch {
+      setError('Could not load memories');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onAdd = async () => {
+    const content = draft.trim();
+    if (!content) return;
+    try {
+      await addMemory(content);
+      setDraft('');
+      await refresh();
+    } catch {
+      setError('Could not add memory');
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    try {
+      await deleteMemory(id);
+      await refresh();
+    } catch {
+      setError('Could not delete memory');
+    }
+  };
+
+  const onClearAll = async () => {
+    if (!confirm('Delete all saved memories?')) return;
+    try {
+      await clearMemories();
+      await refresh();
+    } catch {
+      setError('Could not clear memories');
+    }
+  };
+
+  const onEdit = async (id: string, content: string) => {
+    const next = prompt('Edit memory', content);
+    if (next === null || !next.trim() || next === content) return;
+    try {
+      await updateMemory(id, next.trim());
+      await refresh();
+    } catch {
+      setError('Could not update memory');
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      {memories.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Nothing remembered yet. Facts you share in chat are saved here automatically.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {memories.map((m) => (
+            <li key={m.id} className="flex items-start justify-between gap-2 rounded border px-2 py-1.5 text-sm">
+              <span>{m.content}</span>
+              <span className="flex shrink-0 gap-1">
+                <Button variant="ghost" size="sm" onClick={() => onEdit(m.id, m.content)}>
+                  Edit
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => onDelete(m.id)}>
+                  Delete
+                </Button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex gap-2">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Add a memory…"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void onAdd();
+          }}
+        />
+        <Button size="sm" onClick={() => void onAdd()}>
+          Add
+        </Button>
+      </div>
+      {memories.length > 0 && (
+        <Button variant="outline" size="sm" onClick={() => void onClearAll()}>
+          Clear all
+        </Button>
+      )}
+    </div>
+  );
+}
+```
+
+Match the existing imports in `settings-panel.tsx` (`useState`, `useEffect`, `useCallback`, `Input`, `Button` are likely already imported — extend, don't duplicate) and export `MemorySettings` so the test can import it:
+
+```tsx
+export function MemorySettings() { ... }
+```
+
+Render inside the panel:
+
+```tsx
+<Section title="Memory">
+  <MemorySettings />
+</Section>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (in `nextjs-frontend/`): `npx vitest run src/components/memory-settings.test.tsx`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cd nextjs-frontend && npm run lint && cd ..
+git add nextjs-frontend/src/lib/types.ts nextjs-frontend/src/lib/api.ts nextjs-frontend/src/components/settings-panel.tsx nextjs-frontend/src/components/memory-settings.test.tsx
+git commit -m "feat: memory management section in settings panel"
+```
+
+---
+
+### Task 9: Documentation updates
+
+**Files:**
+- Modify: `CLAUDE.md`, `AGENTS.md`, `README.md`, `nextjs-frontend/CLAUDE.md`, `nextjs-frontend/AGENTS.md`
+
+**Interfaces:**
+- Consumes: final names/signatures from Tasks 1–8.
+- Produces: docs that describe the shipped mechanics.
+
+- [ ] **Step 1: Update root `CLAUDE.md`**
+
+1. In **Directory layout**, add under `app/backend/` and `app/services/` entries:
+
+```
+    user_memory_store.py  Postgres user-memory persistence (user_memories table)
+```
+
+```
+    user_memory_service.py  Persistent user memory: prompt block, LLM extraction, orchestration
+```
+
+and under `app/backend/api/`:
+
+```
+memory.py      /api/memory CRUD (user-level persistent memory)
+```
+
+2. Fix the stale persistence claim: wherever SQLite/`conversation_db.py` is described as the conversation store, state that the canonical store is **PostgreSQL** (`app/backend/conversation_store.py`, `Config.DATABASE_URL`) and that `conversation_db.py` is legacy.
+3. Add an architecture subsection after "Conversation Memory":
+
+```markdown
+### Persistent user memory (`app/backend/user_memory_store.py`, `app/services/user_memory_service.py`)
+Per-user durable memory in Postgres (`user_memories`, FK to `users` with ON DELETE CASCADE).
+After each chat/voice exchange a fire-and-forget task asks the LLM gateway (request's own
+backend/model) for JSON ops (add/update/delete, ≤3/turn) and applies them; extraction failure
+never affects the response. On every chat/RAG/voice request the backend loads the user's
+memories and prepends an "About the user" system block (cap 50). Explicit "remember that…"
+requests are handled by the same extraction prompt. Manual management: `/api/memory` CRUD +
+Settings → Memory panel. Distinct from session-scoped `conversation_memory.py`.
+```
+
+4. In the CI/CD or endpoints area, no change needed beyond the layout entry.
+
+- [ ] **Step 2: Update root `AGENTS.md`**
+
+Add one rule near any existing persistence/auth guidance:
+
+```markdown
+- Any new persisted data must be scoped by `user_id` (see `conversation_store.py` and
+  `user_memory_store.py`); never add user-keyed tables without the FK + user filter.
+```
+
+- [ ] **Step 3: Update `README.md`**
+
+Add a feature bullet in the features list:
+
+```markdown
+- **Persistent personalization** — LiteMindUI remembers durable facts you share (preferences, projects, corrections) across sessions and providers, injects them into every new chat/RAG/voice conversation, and lets you manage them in Settings → Memory.
+```
+
+- [ ] **Step 4: Update `nextjs-frontend/CLAUDE.md` and `nextjs-frontend/AGENTS.md`**
+
+Add a short note (where components/lib are documented):
+
+```markdown
+- User memory management lives in `components/settings-panel.tsx` (`MemorySettings`) and
+  `lib/api.ts` (`getMemories`/`addMemory`/`updateMemory`/`deleteMemory`/`clearMemories`),
+  backed by `/api/memory` (cookie-authenticated, like the rest of the API client).
+```
+
+- [ ] **Step 5: Full verification + commit**
+
+```bash
+uv run pytest -x -q
+uv run ruff check .
+uv run ty check app/backend app/services app/core app/ingestion app/skills main.py config.py logging_config.py
+cd nextjs-frontend && npm run lint && npm run build && cd ..
+git add CLAUDE.md AGENTS.md README.md nextjs-frontend/CLAUDE.md nextjs-frontend/AGENTS.md
+git commit -m "docs: document persistent user memory mechanics"
+```
+
+Expected: all backend tests pass (existing suite + new), lint/type-check clean, frontend lint + build succeed.

--- a/docs/superpowers/specs/2026-08-23-user-memory-design.md
+++ b/docs/superpowers/specs/2026-08-23-user-memory-design.md
@@ -1,0 +1,176 @@
+# Persistent User Memory — Design
+
+**Date:** 2026-08-23
+**Status:** Approved (approach A + Postgres + doc updates)
+**Scope:** Personalization via durable, user-level memory that persists across sessions and is injected into fresh conversations on all surfaces and all LLM providers.
+
+## Problem
+
+LiteMindUI remembers context only within a session (`conversation_memory.py`, session-scoped). When a user starts a fresh conversation, everything they previously taught the assistant (preferences, identity, ongoing projects) is gone. We need persistent per-user memory: captured automatically from conversations plus explicitly manageable by the user.
+
+## Goals
+
+1. Memories survive sessions and are available at the start of any new conversation.
+2. Zero-effort capture: durable facts stated in normal conversation get saved automatically.
+3. Explicit control: "remember that …" works mid-conversation; users can view/add/edit/delete memories in Settings.
+4. Provider-agnostic: identical behavior on Ollama, OpenRouter, and Nvidia NIM.
+5. Surfaces: chat, RAG, and realtime voice all read (and voice/chat write) memory.
+
+## Non-goals (v1)
+
+- No vector/semantic retrieval of memories (inject-all-capped is sufficient below ~100 memories/user; upgrade path later).
+- No global on/off toggle in UI.
+- No cross-user or shared memory; no memory for unauthenticated use (all routes already require auth).
+- No migration of legacy SQLite `conversation_db.py`.
+
+## Naming
+
+Existing `conversation_memory.py` and `/api/chat/memory/*` are **session-scoped** and stay untouched. The new feature is consistently named **user memory**: `user_memory_store.py`, `user_memory_service.py`, `/api/memory/*`, table `user_memories`.
+
+## Architecture
+
+Three units, one dependency direction:
+
+```
+app/backend/user_memory_store.py    # persistence (asyncpg)  ← app/services/user_memory_service.py
+app/services/user_memory_service.py # extraction + formatting (LLM ops via llm_gateway)
+app/backend/api/memory.py           # CRUD router (auth-required)
+```
+
+Surfaces consume the service; none talk to the store directly.
+
+### 1. Storage — `app/backend/user_memory_store.py`
+
+Mirrors `conversation_store.py`: lazy `asyncpg.create_pool` singleton, `init_schema()` idempotent DDL, module-level `get_user_memory_store()`. DSN from `Config.DATABASE_URL`.
+
+```sql
+CREATE TABLE IF NOT EXISTS user_memories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    content TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'auto',   -- 'auto' | 'manual'
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_user_memories_user_id ON user_memories(user_id);
+```
+
+API of the store class (every method user-scoped — same isolation guarantee as conversations):
+
+| Method | Returns |
+|---|---|
+| `list_memories(user_id, limit=50)` | newest-first `List[UserMemoryRecord]` |
+| `add_memory(user_id, content, source="auto")` | `UserMemoryRecord` |
+| `update_memory(user_id, memory_id, content)` | `bool` |
+| `delete_memory(user_id, memory_id)` | `bool` |
+| `clear_memories(user_id)` | count deleted |
+
+`ON DELETE CASCADE` from `users` means GoTrue account deletion wipes memories automatically. `UserMemoryRecord` dataclass with `to_dict()` follows `ConversationRecord`.
+
+### 2. Memory service — `app/services/user_memory_service.py`
+
+Pure functions + one orchestrator; no FastAPI imports.
+
+- `build_memory_block(memories: List[...]) -> str` — returns a system-prompt fragment:
+
+  ```
+  About the user (persistent memory; use when relevant):
+  - <content>
+  - <content>
+  ```
+
+  Empty string when the list is empty. Caller embeds it as a `system` message.
+
+- `extract_memory_ops(user_message, assistant_message, existing_memories, llm_config) -> List[dict]`
+  Calls `llm_gateway.complete_text()` with an extraction prompt containing:
+  - the latest user message and assistant reply,
+  - the existing memory list (id + content),
+  - rules: return strict JSON array only; each op is one of
+    `{"op":"add","content":str}` / `{"op":"update","id":str,"content":str}` / `{"op":"delete","id":str}`;
+  - what qualifies: durable facts only — identity, stable preferences, ongoing projects/goals, corrections of stored facts, explicit "remember that…" requests;
+  - what never qualifies: transient task talk, secrets/credentials/API keys/passwords, opinions about the assistant;
+  - ≤3 ops per turn; empty array `[]` when nothing durable;
+  - prefer `update` of an existing memory over adding a near-duplicate.
+
+  Parsing: strip code fences if present, `json.loads`, validate shape, drop invalid ops silently. Cap enforced in code (first 3 valid ops).
+
+- `apply_memory_ops(store, user_id, ops) -> None` — maps ops to store calls; unknown ids ignored.
+
+- `run_memory_update(user_id, exchange..., llm_config) -> None` — orchestrator meant to run as a fire-and-forget task: extract → apply. All exceptions logged at WARNING, never propagated.
+
+### 3. API — `app/backend/api/memory.py`
+
+Router mounted in `main.py`. All endpoints `Depends(get_current_user)`; Pydantic models added to `api_models.py`.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/memory` | list memories |
+| `POST /api/memory` | add `{content}` → saved with `source="manual"` |
+| `PUT /api/memory/{id}` | edit content |
+| `DELETE /api/memory/{id}` | delete one |
+| `POST /api/memory/clear` | delete all for user |
+
+404 on foreign/unknown ids (user scoping makes ownership implicit).
+
+### 4. Wiring
+
+**Read path (injection):**
+
+- Chat: `_build_messages_with_history()` in `chat.py` loads memories via store and prepends `build_memory_block` as a `system` message before other system messages.
+- RAG: the RAG answer-composition prompt gains the same block (one call site in `rag_service.py` / rag skill).
+- Voice: the pipeline's LLM service system prompt gains the block (loaded once at pipeline start; a long-lived session picks up changes on reconnect — accepted limitation).
+- The client sends nothing new; the backend resolves memories from the JWT `user.id`.
+
+**Write path (extraction trigger):**
+
+- `chat_endpoint`: after a successful response, schedule `asyncio.create_task(run_memory_update(...))`.
+- `chat_stream`: the event generator accumulates streamed assistant text; after the stream completes normally, schedules the same task. Aborted/errored streams skip extraction.
+- Voice: after each completed LLM turn in `voice_pipeline.py`, same hook using the turn's transcript pair.
+- Extraction uses the **request's own backend/model/api config** through the gateway — no separate extraction-model setting.
+
+### 5. Error handling
+
+| Failure | Behavior |
+|---|---|
+| Extraction LLM call fails / times out (~15 s) | log WARNING, skip; chat response unaffected |
+| Unparseable extraction JSON | skip silently (log DEBUG) |
+| Store write/read fails | log WARNING; read failure degrades to no-memory-block response |
+| Fire-and-forget task crash | contained by `run_memory_update`'s catch-all |
+
+Extraction never blocks, delays, or fails the user-visible response.
+
+### 6. Frontend
+
+Settings panel gains a "Personalization / Memory" section: list memories (newest first), inline edit, delete per row, add box, clear-all with confirmation. Uses a thin `memoryApi` addition in `lib/api.ts`. No toggle, no categories v1.
+
+### 7. Documentation updates
+
+Update the project docs so the mechanics stay accurate:
+
+- `CLAUDE.md` (root): directory layout entries for the two new modules + router; architecture overview section describing user memory (capture + injection); fix the stale claim that conversations persist in SQLite — canonical store is Postgres (`conversation_store.py`); document `/api/memory` surface.
+- `AGENTS.md` (root): note the user-scoping rule for any new persistence (memories included).
+- `README.md`: feature bullet under personalization/memory.
+- `nextjs-frontend/CLAUDE.md` and `nextjs-frontend/AGENTS.md`: settings memory panel + `memoryApi` client notes.
+
+### 8. Testing
+
+Backend (`tests/test_user_memory*.py`):
+
+- Ops parsing: valid JSON, fenced JSON, malformed JSON → `[]`, op-shape validation, >3 ops capped, secret-like content rejected by prompt contract is *not* re-checked in code (prompt-level rule; documented).
+- `build_memory_block`: empty list → `""`; ordering; header text.
+- Store CRUD against a test Postgres (or `asyncpg` test DSN), including cross-user isolation (user B cannot read/update/delete user A's memory).
+- Injection: `_build_messages_with_history` includes/excludes the memory system message correctly.
+- One integration-style happy path with mocked gateway: exchange → expected ops applied.
+
+Frontend: component test for the settings memory panel following existing test patterns.
+
+## Data flow summary
+
+```
+Fresh conversation ─► route auth (JWT) ─► store.list_memories(user.id)
+                      ─► build_memory_block ─► system message ─► llm_gateway ─► provider
+
+Exchange completes ─► create_task(run_memory_update)
+                      ─► complete_text(extraction prompt w/ existing memories)
+                      ─► parse ops ─► store.add/update/delete ─► done (logged)
+```

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 from app.backend.api import auth as auth_api
 from app.backend.api import chat as chat_api
 from app.backend.api import conversations as conversations_api
+from app.backend.api import memory as memory_api
 from app.backend.api import voice as voice_api
 from app.backend.api.auth_deps import User, get_current_user
 from app.backend.api.security_utils import sanitize_filename, validate_file_size
@@ -341,6 +342,7 @@ app.include_router(auth_api.router)
 app.include_router(conversations_api.router)
 app.include_router(chat_api.router)
 app.include_router(voice_api.router)
+app.include_router(memory_api.router)
 
 # Templates
 try:

--- a/main.py
+++ b/main.py
@@ -775,9 +775,13 @@ async def rag_query(request: RAGQueryRequestEnhanced, user: User = Depends(get_c
         if skill is None:
             raise HTTPException(status_code=400, detail="No compatible RAG skill found for request")
 
+        from app.services.user_memory_service import load_memory_block
+
+        memory_block = await load_memory_block(user.id)
+
         async def event_generator():
             logger.info("Routing RAG query through skill '%s'", skill.name)
-            async for chunk in skill.stream(request, rag_service):
+            async for chunk in skill.stream(request, rag_service, memory_block=memory_block):
                 yield chunk + "\n"
 
         return StreamingResponse(event_generator(), media_type="text/plain")

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ from app.backend.api.security_utils import sanitize_filename, validate_file_size
 from app.backend.core.config import DEFAULT_RAG_CONFIG
 from app.backend.core.embeddings import create_embedding_function, resolve_embedding_provider
 from app.backend.core.ollama_models import build_enhanced_model_payload
+from app.backend.user_memory_store import get_user_memory_store
 from app.services.ollama import stream_ollama
 from app.services.rag_service import RAGService
 from app.services.speech_service import get_speech_service, preload_stt_model
@@ -180,6 +181,13 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"RAG service initialization failed: {e}")
         rag_service = None
+
+    # Ensure the user-memory table exists (idempotent); degrade gracefully
+    try:
+        await get_user_memory_store().init_schema()
+        logger.info("User memory store ready")
+    except Exception as e:
+        logger.warning(f"User memory schema init skipped: {e}")
 
     # Restore configuration
     if rag_service is None:

--- a/nextjs-frontend/AGENTS.md
+++ b/nextjs-frontend/AGENTS.md
@@ -50,6 +50,9 @@ public/             Static assets
 
 ### Rules
 - Business logic belongs in `src/lib/` or `src/hooks/`, not in components.
+- User memory management lives in `src/components/settings-panel.tsx` (`MemorySettings`) and
+  `src/lib/api.ts` (`getMemories`/`addMemory`/`updateMemory`/`deleteMemory`/`clearMemories`),
+  backed by `/api/memory` (cookie-authenticated, like the rest of the API client).
 - shadcn/ui primitives in `src/components/ui/` are auto-generated — **do not hand-edit** them.
   Re-generate with `npx shadcn add <component>` if you need changes.
 - New pages go in `src/app/<route>/page.tsx`.

--- a/nextjs-frontend/src/components/memory-settings.test.tsx
+++ b/nextjs-frontend/src/components/memory-settings.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemorySettings } from './settings-panel';
+import * as api from '@/lib/api';
+import type { MemoryRecord } from '@/lib/types';
+
+vi.mock('@/lib/api', () => ({
+  getMemories: vi.fn(),
+  addMemory: vi.fn(),
+  updateMemory: vi.fn(),
+  deleteMemory: vi.fn(),
+  clearMemories: vi.fn(),
+}));
+
+const mem = (id: string, content: string): MemoryRecord => ({
+  id,
+  content,
+  source: 'auto',
+  created_at: '2026-08-23T00:00:00',
+  updated_at: '2026-08-23T00:00:00',
+});
+
+describe('MemorySettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getMemories).mockResolvedValue([mem('m1', 'Prefers dark mode')]);
+  });
+
+  it('lists memories on load', async () => {
+    render(<MemorySettings />);
+    expect(await screen.findByText('Prefers dark mode')).toBeInTheDocument();
+  });
+
+  it('adds a memory', async () => {
+    vi.mocked(api.addMemory).mockResolvedValue(mem('m2', 'New fact'));
+    render(<MemorySettings />);
+    await screen.findByText('Prefers dark mode');
+    fireEvent.change(screen.getByPlaceholderText(/add a memory/i), {
+      target: { value: 'New fact' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+    await waitFor(() => expect(api.addMemory).toHaveBeenCalledWith('New fact'));
+    expect(await screen.findByText('New fact')).toBeInTheDocument();
+  });
+
+  it('deletes a memory', async () => {
+    vi.mocked(api.deleteMemory).mockResolvedValue(undefined);
+    render(<MemorySettings />);
+    await screen.findByText('Prefers dark mode');
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    await waitFor(() => expect(api.deleteMemory).toHaveBeenCalledWith('m1'));
+    await waitFor(() =>
+      expect(screen.queryByText('Prefers dark mode')).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/nextjs-frontend/src/components/settings-panel.tsx
+++ b/nextjs-frontend/src/components/settings-panel.tsx
@@ -136,7 +136,8 @@ export function MemorySettings() {
     if (!content) return;
     try {
       const created = await addMemory(content);
-      setMemories((ms) => [...ms, created]);
+      // Backend lists newest-first; prepend so the new entry renders at the top.
+      setMemories((ms) => [created, ...ms]);
       setDraft('');
       setError(null);
     } catch {

--- a/nextjs-frontend/src/components/settings-panel.tsx
+++ b/nextjs-frontend/src/components/settings-panel.tsx
@@ -23,9 +23,17 @@ import {
 } from '@/components/ui/select';
 import { KnowledgeBaseSection } from '@/components/knowledge-base';
 import { useAppStore } from '@/lib/store';
-import { getEnhancedModels, checkSerpStatus } from '@/lib/api';
+import {
+  getEnhancedModels,
+  checkSerpStatus,
+  getMemories,
+  addMemory,
+  updateMemory,
+  deleteMemory,
+  clearMemories,
+} from '@/lib/api';
 import { cn } from '@/lib/utils';
-import type { Model, BackendType } from '@/lib/types';
+import type { Model, BackendType, MemoryRecord } from '@/lib/types';
 
 function Section({
   title,
@@ -103,6 +111,121 @@ const GENERATION_DEFAULTS = {
   seed: null,
   stopSequences: '',
 } as const;
+
+export function MemorySettings() {
+  const [memories, setMemories] = React.useState<MemoryRecord[]>([]);
+  const [draft, setDraft] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    getMemories()
+      .then((ms) => {
+        if (!cancelled) setMemories(ms);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load memories');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onAdd = async () => {
+    const content = draft.trim();
+    if (!content) return;
+    try {
+      const created = await addMemory(content);
+      setMemories((ms) => [...ms, created]);
+      setDraft('');
+      setError(null);
+    } catch {
+      setError('Could not add memory');
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    try {
+      await deleteMemory(id);
+      setMemories((ms) => ms.filter((m) => m.id !== id));
+      setError(null);
+    } catch {
+      setError('Could not delete memory');
+    }
+  };
+
+  const onClearAll = async () => {
+    if (!confirm('Delete all saved memories?')) return;
+    try {
+      await clearMemories();
+      setMemories([]);
+      setError(null);
+    } catch {
+      setError('Could not clear memories');
+    }
+  };
+
+  const onEdit = async (id: string, content: string) => {
+    const next = prompt('Edit memory', content);
+    if (next === null || !next.trim() || next === content) return;
+    try {
+      await updateMemory(id, next.trim());
+      setMemories((ms) => ms.map((m) => (m.id === id ? { ...m, content: next.trim() } : m)));
+      setError(null);
+    } catch {
+      setError('Could not update memory');
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      {memories.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Nothing remembered yet. Facts you share in chat are saved here automatically.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {memories.map((m) => (
+            <li
+              key={m.id}
+              className="flex items-start justify-between gap-2 rounded border px-2 py-1.5 text-sm"
+            >
+              <span>{m.content}</span>
+              <span className="flex shrink-0 gap-1">
+                <Button variant="ghost" size="sm" onClick={() => onEdit(m.id, m.content)}>
+                  Edit
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => onDelete(m.id)}>
+                  Delete
+                </Button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex gap-2">
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Add a memory…"
+          aria-label="Add a memory"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void onAdd();
+          }}
+        />
+        <Button size="sm" onClick={() => void onAdd()}>
+          Add
+        </Button>
+      </div>
+      {memories.length > 0 && (
+        <Button variant="outline" size="sm" onClick={() => void onClearAll()}>
+          Clear all
+        </Button>
+      )}
+    </div>
+  );
+}
 
 export function SettingsPanel({
   open,
@@ -491,6 +614,12 @@ export function SettingsPanel({
 
             <Section title="Knowledge Base">
               <KnowledgeBaseSection />
+            </Section>
+
+            <Separator />
+
+            <Section title="Memory">
+              <MemorySettings />
             </Section>
           </div>
         </ScrollArea>

--- a/nextjs-frontend/src/lib/api.ts
+++ b/nextjs-frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, Model, RagFile, RagStatusResponse } from '@/lib/types';
+import type { ChatMessage, Model, RagFile, RagStatusResponse, MemoryRecord } from '@/lib/types';
 
 /**
  * Frontend API client for the FastAPI backend.
@@ -308,6 +308,52 @@ export const authApi = {
     return (await res.json()) as AuthUserResponse;
   },
 };
+
+// ─── User memory (personalization) ───────────────────────────────────────
+
+export async function getMemories(): Promise<MemoryRecord[]> {
+  const res = await fetch(`${API_BASE}/api/memory`, { credentials: 'include', cache: 'no-store' });
+  if (!res.ok) throw new Error(`Failed to load memories: ${res.status}`);
+  return res.json();
+}
+
+export async function addMemory(content: string): Promise<MemoryRecord> {
+  const res = await fetch(`${API_BASE}/api/memory`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error(`Failed to add memory: ${res.status}`);
+  return res.json();
+}
+
+export async function updateMemory(id: string, content: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/memory/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error(`Failed to update memory: ${res.status}`);
+}
+
+export async function deleteMemory(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/memory/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Failed to delete memory: ${res.status}`);
+}
+
+export async function clearMemories(): Promise<{ deleted: number }> {
+  const res = await fetch(`${API_BASE}/api/memory/clear`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Failed to clear memories: ${res.status}`);
+  return res.json();
+}
 
 // ─── Error extraction ───────────────────────────────────────────────────────────
 

--- a/nextjs-frontend/src/lib/types.ts
+++ b/nextjs-frontend/src/lib/types.ts
@@ -72,3 +72,12 @@ export interface AppSettings {
   enableGenerativeUI: boolean;
   genUIDisplayMode: 'rendered' | 'code';
 }
+
+/** A persisted per-user memory record (GET/POST /api/memory). */
+export interface MemoryRecord {
+  id: string;
+  content: string;
+  source: 'auto' | 'manual';
+  created_at: string;
+  updated_at: string;
+}

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -1,0 +1,104 @@
+"""API tests for /api/memory — auth required, user-scoped CRUD."""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class FakeStore:
+    def __init__(self):
+        self.rows = {}
+
+    async def list_memories(self, user_id, limit=50):
+        result = [r for r in self.rows.values() if r.user_id == user_id]
+        return result
+
+    async def add_memory(self, user_id, content, source="auto"):
+        from app.backend.user_memory_store import UserMemoryRecord
+
+        rec = UserMemoryRecord(
+            id=str(uuid.uuid4()), user_id=user_id, content=content, source=source,
+            created_at="2026-08-23T00:00:00", updated_at="2026-08-23T00:00:00",
+        )
+        self.rows[rec.id] = rec
+        return rec
+
+    async def update_memory(self, user_id, memory_id, content):
+        r = self.rows.get(memory_id)
+        if not r or r.user_id != user_id:
+            return False
+        r.content = content
+        return True
+
+    async def delete_memory(self, user_id, memory_id):
+        r = self.rows.get(memory_id)
+        if not r or r.user_id != user_id:
+            return False
+        del self.rows[memory_id]
+        return True
+
+    async def clear_memories(self, user_id):
+        ids = [i for i, r in self.rows.items() if r.user_id == user_id]
+        for i in ids:
+            del self.rows[i]
+        return len(ids)
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    from app.backend.api.auth_deps import User, get_current_user
+    from main import app
+
+    store = FakeStore()
+    # Patch the function where it's defined to affect all importers
+    def get_store():
+        return store
+    monkeypatch.setattr("app.backend.user_memory_store.get_user_memory_store", get_store)
+    # Same override pattern as tests/test_chat_auth.py:_make_app
+    # Create a single user instance to return consistently
+    test_user = User(id=str(uuid.uuid4()), email="u1@x.com")
+    app.dependency_overrides[get_current_user] = lambda: test_user
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_memory_requires_auth():
+    from main import app
+
+    with TestClient(app) as c:
+        assert c.get("/api/memory").status_code == 401
+
+
+def test_memory_crud_roundtrip(client):
+    resp = client.post("/api/memory", json={"content": "Prefers dark mode"})
+    assert resp.status_code == 200
+    mid = resp.json()["id"]
+    assert resp.json()["source"] == "manual"
+
+    listed = client.get("/api/memory").json()
+    assert [m["content"] for m in listed] == ["Prefers dark mode"]
+
+    assert client.put(f"/api/memory/{mid}", json={"content": "Prefers light mode"}).status_code == 200
+    assert client.get("/api/memory").json()[0]["content"] == "Prefers light mode"
+
+    assert client.delete(f"/api/memory/{mid}").status_code == 200
+    assert client.get("/api/memory").json() == []
+
+
+def test_memory_add_rejects_blank_content(client):
+    assert client.post("/api/memory", json={"content": "   "}).status_code == 422
+
+
+def test_memory_update_unknown_id_404(client):
+    assert client.put(f"/api/memory/{uuid.uuid4()}", json={"content": "x"}).status_code == 404
+
+
+def test_memory_clear(client):
+    client.post("/api/memory", json={"content": "a"})
+    client.post("/api/memory", json={"content": "b"})
+    resp = client.post("/api/memory/clear")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == 2
+    assert client.get("/api/memory").json() == []

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -99,6 +99,10 @@ def test_memory_add_rejects_blank_content(client):
     assert client.post("/api/memory", json={"content": "   "}).status_code == 422
 
 
+def test_memory_add_rejects_overlong_content(client):
+    assert client.post("/api/memory", json={"content": "x" * 501}).status_code == 422
+
+
 def test_memory_update_unknown_id_404(client):
     assert client.put(f"/api/memory/{uuid.uuid4()}", json={"content": "x"}).status_code == 404
 

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -65,10 +65,18 @@ def client(monkeypatch):
 
 
 def test_memory_requires_auth():
-    from main import app
+    # Fresh app instead of main.app: other test modules install module-level
+    # dependency_overrides on the shared main.app that never clean up, which
+    # would authenticate this request and turn the 401 into a store error.
+    # Router mounting on main.app is covered by the fixture-based tests below.
+    from fastapi import FastAPI
 
-    with TestClient(app) as c:
-        assert c.get("/api/memory").status_code == 401
+    from app.backend.api.memory import router
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    assert client.get("/api/memory").status_code == 401
 
 
 def test_memory_crud_roundtrip(client):

--- a/tests/test_user_memory_service.py
+++ b/tests/test_user_memory_service.py
@@ -38,8 +38,9 @@ def test_parse_memory_ops_valid_json():
 
 
 def test_parse_memory_ops_strips_code_fence():
-    raw = '```json\n[{"op": "delete", "id": "abc"}]\n```'
-    assert parse_memory_ops(raw) == [{"op": "delete", "id": "abc"}]
+    memory_id = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    raw = '```json\n[{"op": "delete", "id": "%s"}]\n```' % memory_id
+    assert parse_memory_ops(raw) == [{"op": "delete", "id": memory_id}]
 
 
 def test_parse_memory_ops_invalid_json_returns_empty():
@@ -66,6 +67,22 @@ def test_parse_memory_ops_rejects_bad_shapes():
 def test_parse_memory_ops_caps_at_three():
     raw = "[" + ",".join(f'{{"op": "add", "content": "c{i}"}}' for i in range(10)) + "]"
     assert len(parse_memory_ops(raw)) == MAX_MEMORY_OPS_PER_TURN
+
+
+VALID_MEMORY_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+
+def test_parse_memory_ops_drops_mangled_uuid_but_keeps_siblings():
+    """A mangled UUID on one op must not abort the whole batch (local models do this)."""
+    raw = (
+        '[{"op": "delete", "id": "not-a-uuid"},'
+        f'{{"op": "add", "content": "Kept"}},'
+        f'{{"op": "update", "id": "{VALID_MEMORY_ID}", "content": "Edited"}}]'
+    )
+    assert parse_memory_ops(raw) == [
+        {"op": "add", "content": "Kept"},
+        {"op": "update", "id": VALID_MEMORY_ID, "content": "Edited"},
+    ]
 
 
 def test_parse_memory_ops_truncates_overlong_content():
@@ -132,6 +149,36 @@ async def test_apply_memory_ops_dispatches_to_store():
     assert store.added == [("user-1", "New fact", "auto")]
     assert store.updated == [("user-1", "m1", "Edited")]
     assert store.deleted == [("user-1", "m2")]
+
+
+@pytest.mark.asyncio
+async def test_apply_memory_ops_continues_past_a_failing_op(caplog):
+    """One failing store call must not drop the ops after it."""
+
+    class FlakyStore(FakeStore):
+        def __init__(self):
+            super().__init__()
+            self._update_calls = 0
+
+        async def update_memory(self, user_id, memory_id, content):
+            self._update_calls += 1
+            if self._update_calls == 1:
+                raise RuntimeError("transient db error")
+            return await super().update_memory(user_id, memory_id, content)
+
+    store = FlakyStore()
+    with caplog.at_level("WARNING"):
+        await apply_memory_ops(
+            store, "user-1",
+            [
+                {"op": "update", "id": "m1", "content": "Fails once"},
+                {"op": "delete", "id": "m2"},
+            ],
+        )
+    assert store._update_calls == 1
+    assert store.updated == []
+    assert store.deleted == [("user-1", "m2")]
+    assert any("Memory op update failed" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_memory_service.py
+++ b/tests/test_user_memory_service.py
@@ -1,0 +1,65 @@
+"""Tests for user_memory_service pure functions."""
+
+from app.services.user_memory_service import (
+    MAX_MEMORY_OPS_PER_TURN,
+    build_memory_block,
+    parse_memory_ops,
+)
+
+
+class FakeMemory:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_build_memory_block_empty():
+    assert build_memory_block([]) == ""
+
+
+def test_build_memory_block_formats_facts():
+    block = build_memory_block([FakeMemory("Prefers concise answers"), FakeMemory("Name is Alex")])
+    assert block.startswith("About the user (persistent memory; use when relevant):")
+    assert "- Prefers concise answers" in block
+    assert "- Name is Alex" in block
+
+
+def test_parse_memory_ops_valid_json():
+    raw = '[{"op": "add", "content": "Likes Rust"}]'
+    assert parse_memory_ops(raw) == [{"op": "add", "content": "Likes Rust"}]
+
+
+def test_parse_memory_ops_strips_code_fence():
+    raw = '```json\n[{"op": "delete", "id": "abc"}]\n```'
+    assert parse_memory_ops(raw) == [{"op": "delete", "id": "abc"}]
+
+
+def test_parse_memory_ops_invalid_json_returns_empty():
+    assert parse_memory_ops("not json at all") == []
+    assert parse_memory_ops("") == []
+
+
+def test_parse_memory_ops_rejects_bad_shapes():
+    raw = """
+    [
+      {"op": "add"},
+      {"op": "add", "content": ""},
+      {"op": "bogus", "content": "x"},
+      {"op": "update", "content": "no id"},
+      {"op": "delete", "id": 42},
+      {"op": "add", "content": 7},
+      "just a string",
+      {"op": "add", "content": "Valid one"}
+    ]
+    """
+    assert parse_memory_ops(raw) == [{"op": "add", "content": "Valid one"}]
+
+
+def test_parse_memory_ops_caps_at_three():
+    raw = "[" + ",".join(f'{{"op": "add", "content": "c{i}"}}' for i in range(10)) + "]"
+    assert len(parse_memory_ops(raw)) == MAX_MEMORY_OPS_PER_TURN
+
+
+def test_parse_memory_ops_truncates_overlong_content():
+    raw = '[{"op": "add", "content": "' + "x" * 600 + '"}]'
+    ops = parse_memory_ops(raw)
+    assert len(ops[0]["content"]) == 500

--- a/tests/test_user_memory_service.py
+++ b/tests/test_user_memory_service.py
@@ -1,9 +1,18 @@
 """Tests for user_memory_service pure functions."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.services.user_memory_service as ums
 from app.services.user_memory_service import (
     MAX_MEMORY_OPS_PER_TURN,
+    apply_memory_ops,
     build_memory_block,
+    extract_memory_ops,
+    load_memory_block,
     parse_memory_ops,
+    run_memory_update,
 )
 
 
@@ -63,3 +72,89 @@ def test_parse_memory_ops_truncates_overlong_content():
     raw = '[{"op": "add", "content": "' + "x" * 600 + '"}]'
     ops = parse_memory_ops(raw)
     assert len(ops[0]["content"]) == 500
+
+
+# ── Extraction and orchestration (Task 3) ──────────────────────
+
+
+
+class FakeStore:
+    def __init__(self, memories=None):
+        self.memories = list(memories or [])
+        self.added = []
+        self.updated = []
+        self.deleted = []
+
+    async def list_memories(self, user_id, limit=50):
+        return self.memories
+
+    async def add_memory(self, user_id, content, source="auto"):
+        self.added.append((user_id, content, source))
+        return type('R', (), {'content': content})()
+
+    async def update_memory(self, user_id, memory_id, content):
+        self.updated.append((user_id, memory_id, content))
+        return True
+
+    async def delete_memory(self, user_id, memory_id):
+        self.deleted.append((user_id, memory_id))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_extract_memory_ops_sends_prompt_and_parses():
+    with patch.object(ums, "complete_text", new=AsyncMock(return_value='[{"op": "add", "content": "Owns a dog"}]')) as mock_llm:
+        ops = await extract_memory_ops("I own a dog named Rex", "That's lovely!", [], backend="ollama", model="gemma3:1b")
+    assert ops == [{"op": "add", "content": "Owns a dog"}]
+    sent = mock_llm.call_args.args[0]
+    assert any(m["role"] == "system" for m in sent)
+    assert "I own a dog named Rex" in sent[-1]["content"]
+    assert mock_llm.call_args.kwargs["backend"] == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_extract_memory_ops_returns_empty_on_llm_error():
+    with patch.object(ums, "complete_text", new=AsyncMock(side_effect=RuntimeError("provider down"))):
+        assert await extract_memory_ops("hi", "hello", []) == []
+
+
+@pytest.mark.asyncio
+async def test_apply_memory_ops_dispatches_to_store():
+    store = FakeStore()
+    await apply_memory_ops(
+        store, "user-1",
+        [
+            {"op": "add", "content": "New fact"},
+            {"op": "update", "id": "m1", "content": "Edited"},
+            {"op": "delete", "id": "m2"},
+        ],
+    )
+    assert store.added == [("user-1", "New fact", "auto")]
+    assert store.updated == [("user-1", "m1", "Edited")]
+    assert store.deleted == [("user-1", "m2")]
+
+
+@pytest.mark.asyncio
+async def test_run_memory_update_swallows_all_errors():
+    with patch.object(ums, "get_user_memory_store", side_effect=RuntimeError("db down")):
+        await run_memory_update("user-1", "hi", "hello")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_run_memory_update_happy_path():
+    store = FakeStore(memories=[])
+    with patch.object(ums, "get_user_memory_store", return_value=store), \
+         patch.object(ums, "complete_text", new=AsyncMock(return_value='[{"op": "add", "content": "Lives in Berlin"}]')):
+        await run_memory_update("user-1", "I live in Berlin", "Nice city!")
+    assert store.added == [("user-1", "Lives in Berlin", "auto")]
+
+
+@pytest.mark.asyncio
+async def test_load_memory_block_empty_user():
+    assert await load_memory_block(None) == ""
+
+
+@pytest.mark.asyncio
+async def test_load_memory_block_degrades_on_store_error():
+    with patch.object(ums, "get_user_memory_store", side_effect=RuntimeError("db down")):
+        assert await load_memory_block("user-1") == ""

--- a/tests/test_user_memory_store.py
+++ b/tests/test_user_memory_store.py
@@ -1,0 +1,116 @@
+"""Unit tests for UserMemoryStore.
+
+Uses an in-memory FakeStore subclass (same approach as
+tests/test_conversation_store.py) so no live PostgreSQL is required. The focus
+is user isolation: one user can never read or mutate another user's memories.
+"""
+
+import uuid
+
+import pytest
+
+from app.backend.user_memory_store import UserMemoryRecord, UserMemoryStore
+
+
+class FakeUserMemoryStore(UserMemoryStore):
+    """In-memory implementation of the same async interface."""
+
+    def __init__(self):
+        self.memories = {}  # id -> dict(row fields)
+        self._next_timestamp = 0
+
+    async def init_schema(self):
+        return None
+
+    async def list_memories(self, user_id, limit=50):
+        rows = [m for m in self.memories.values() if m["user_id"] == user_id]
+        rows.sort(key=lambda m: m["created_at"], reverse=True)
+        return [self._record(m) for m in rows[:limit]]
+
+    async def add_memory(self, user_id, content, source="auto"):
+        mid = str(uuid.uuid4())
+        timestamp = f"2026-08-23T00:00:{self._next_timestamp:02d}"
+        row = {
+            "id": mid, "user_id": user_id, "content": content, "source": source,
+            "created_at": timestamp, "updated_at": timestamp,
+        }
+        self.memories[mid] = row
+        self._next_timestamp += 1
+        return self._record(row)
+
+    async def update_memory(self, user_id, memory_id, content):
+        m = self.memories.get(memory_id)
+        if not m or m["user_id"] != user_id:
+            return False
+        m["content"] = content
+        timestamp = f"2026-08-23T00:00:{self._next_timestamp:02d}"
+        m["updated_at"] = timestamp
+        self._next_timestamp += 1
+        return True
+
+    async def delete_memory(self, user_id, memory_id):
+        m = self.memories.get(memory_id)
+        if not m or m["user_id"] != user_id:
+            return False
+        del self.memories[memory_id]
+        return True
+
+    async def clear_memories(self, user_id):
+        ids = [i for i, m in self.memories.items() if m["user_id"] == user_id]
+        for i in ids:
+            del self.memories[i]
+        return len(ids)
+
+    @staticmethod
+    def _record(m):
+        return UserMemoryRecord(**m)
+
+
+USER_A = str(uuid.uuid4())
+USER_B = str(uuid.uuid4())
+
+
+@pytest.mark.asyncio
+async def test_add_and_list_scoped_to_user():
+    store = FakeUserMemoryStore()
+    await store.add_memory(USER_A, "Prefers concise answers")
+    await store.add_memory(USER_B, "Works on robotics")
+    assert [m.content for m in await store.list_memories(USER_A)] == ["Prefers concise answers"]
+
+
+@pytest.mark.asyncio
+async def test_update_requires_owner():
+    store = FakeUserMemoryStore()
+    mem = await store.add_memory(USER_A, "Old fact")
+    assert await store.update_memory(USER_B, mem.id, "hijack") is False
+    assert await store.update_memory(USER_A, mem.id, "New fact") is True
+    assert (await store.list_memories(USER_A))[0].content == "New fact"
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_owner():
+    store = FakeUserMemoryStore()
+    mem = await store.add_memory(USER_A, "fact")
+    assert await store.delete_memory(USER_B, mem.id) is False
+    assert await store.delete_memory(USER_A, mem.id) is True
+    assert await store.list_memories(USER_A) == []
+
+
+@pytest.mark.asyncio
+async def test_clear_only_own():
+    store = FakeUserMemoryStore()
+    await store.add_memory(USER_A, "a1")
+    await store.add_memory(USER_A, "a2")
+    await store.add_memory(USER_B, "b1")
+    assert await store.clear_memories(USER_A) == 2
+    assert len(await store.list_memories(USER_B)) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_respects_limit_and_newest_first():
+    store = FakeUserMemoryStore()
+    for i in range(5):
+        await store.add_memory(USER_A, f"fact {i}")
+    rows = await store.list_memories(USER_A, limit=3)
+    assert len(rows) == 3
+    assert rows[0].content == "fact 4"

--- a/tests/test_user_memory_store.py
+++ b/tests/test_user_memory_store.py
@@ -5,6 +5,7 @@ tests/test_conversation_store.py) so no live PostgreSQL is required. The focus
 is user isolation: one user can never read or mutate another user's memories.
 """
 
+import os
 import uuid
 
 import pytest
@@ -114,3 +115,51 @@ async def test_list_respects_limit_and_newest_first():
     rows = await store.list_memories(USER_A, limit=3)
     assert len(rows) == 3
     assert rows[0].content == "fact 4"
+
+
+# ── Real-store integration (spec §8) ─────────────────────────────────────────
+
+_REAL_DSN = os.environ.get("TEST_DATABASE_URL", "")
+_requires_postgres = pytest.mark.skipif(
+    not _REAL_DSN, reason="set TEST_DATABASE_URL to run real-store integration tests"
+)
+
+
+@_requires_postgres
+@pytest.mark.asyncio
+async def test_real_store_crud_and_cross_user_isolation():
+    """Runs only when TEST_DATABASE_URL points at a disposable Postgres."""
+    import asyncpg
+
+    from app.backend.conversation_store import SCHEMA_SQL as CORE_SCHEMA_SQL
+    from app.backend.user_memory_store import UserMemoryStore
+
+    store = UserMemoryStore(_REAL_DSN)
+    # user_memories has an FK on users(id); make sure both tables exist and
+    # create real user rows so the inserts below satisfy the constraint.
+    pool = await asyncpg.create_pool(_REAL_DSN)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(CORE_SCHEMA_SQL)
+            await store.init_schema()
+            user_a, user_b = str(uuid.uuid4()), str(uuid.uuid4())
+            await conn.executemany(
+                "INSERT INTO users (id, email) VALUES ($1, $2)",
+                [(uuid.UUID(user_a), f"{user_a}@test.local"), (uuid.UUID(user_b), f"{user_b}@test.local")],
+            )
+        try:
+            rec = await store.add_memory(user_a, "likes tea")
+            assert rec.source == "auto"
+            assert [r.content for r in await store.list_memories(user_a)] == ["likes tea"]
+            # B sees nothing of A's, and cannot mutate or delete it
+            assert await store.list_memories(user_b) == []
+            assert not await store.update_memory(user_b, rec.id, "hacked")
+            assert not await store.delete_memory(user_b, rec.id)
+            assert (await store.list_memories(user_a))[0].content == "likes tea"
+        finally:
+            await store.clear_memories(user_a)
+            await store.clear_memories(user_b)
+            async with pool.acquire() as conn:
+                await conn.execute("DELETE FROM users WHERE id = ANY($1::uuid[])", [user_a, user_b])
+    finally:
+        await pool.close()

--- a/tests/test_user_memory_wiring.py
+++ b/tests/test_user_memory_wiring.py
@@ -107,3 +107,29 @@ async def test_rag_query_injects_memory_block():
     assert "answer" in chunks
     assert block in sent
     assert sent.index(block) < sent.index({"role": "user", "content": "hi"})
+
+
+# ── Voice pipeline ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_voice_pipeline_prepends_memory_to_system_instruction():
+    from app.services.voice_pipeline import VoiceSettings
+
+    settings = VoiceSettings(user_id="u-1", system_instruction="You are a helpful voice assistant.")
+    with patch("app.services.voice_pipeline.load_memory_block", new=AsyncMock(return_value="About the user:\n- Likes tea")):
+        from app.services.voice_pipeline import apply_memory_to_voice_settings
+
+        await apply_memory_to_voice_settings(settings)
+    assert settings.system_instruction.startswith("You are a helpful voice assistant.")
+    assert "Likes tea" in settings.system_instruction
+
+
+@pytest.mark.asyncio
+async def test_voice_pipeline_skips_memory_without_user():
+    from app.services.voice_pipeline import VoiceSettings, apply_memory_to_voice_settings
+
+    settings = VoiceSettings(user_id=None, system_instruction="base")
+    with patch("app.services.voice_pipeline.load_memory_block", new=AsyncMock(return_value="X")) as m:
+        await apply_memory_to_voice_settings(settings)
+    m.assert_not_called()
+    assert settings.system_instruction == "base"

--- a/tests/test_user_memory_wiring.py
+++ b/tests/test_user_memory_wiring.py
@@ -1,11 +1,17 @@
 """Chat wiring: memory block injection + post-exchange extraction trigger."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import app.backend.api.chat as chat_api
 from app.backend.models.api_models import ChatRequestEnhanced
+
+
+async def aiter(items):
+    """Wrap a plain list as an async iterator (shadows the builtin, which needs an async iterable)."""
+    for item in items:
+        yield item
 
 
 def _request(**overrides):
@@ -71,3 +77,33 @@ async def test_handle_chat_request_without_user_skips_memory_load():
          patch.object(chat_api, "complete_text", new=AsyncMock(return_value="ok")):
         await chat_api._handle_chat_request(_request())
     mock_load.assert_not_called()
+
+
+# ── RAG injection ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_rag_query_injects_memory_block():
+    """query(..., memory_block=...) must place the block before conversation history."""
+    from app.services import rag_service as rag_module
+    from app.services.rag_service import RAGService
+
+    svc = RAGService.__new__(RAGService)  # retrieval + prompt seams are patched below
+
+    block = {"role": "system", "content": "About the user:\n- Likes tea"}
+    with patch.object(svc, "get_retrieval_records", return_value=[]), \
+         patch.object(svc, "build_grounded_user_prompt", return_value="grounded"), \
+         patch.object(rag_module, "stream_completion", new=MagicMock(return_value=aiter(["answer"]))):
+        chunks = [
+            c
+            async for c in svc.query(
+                "what is x",
+                system_prompt="You are helpful.",
+                messages=[{"role": "user", "content": "hi"}],
+                memory_block="About the user:\n- Likes tea",
+            )
+        ]
+        sent = rag_module.stream_completion.call_args.args[0]
+
+    assert "answer" in chunks
+    assert block in sent
+    assert sent.index(block) < sent.index({"role": "user", "content": "hi"})

--- a/tests/test_user_memory_wiring.py
+++ b/tests/test_user_memory_wiring.py
@@ -1,0 +1,73 @@
+"""Chat wiring: memory block injection + post-exchange extraction trigger."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.backend.api.chat as chat_api
+from app.backend.models.api_models import ChatRequestEnhanced
+
+
+def _request(**overrides):
+    base = dict(message="Remember I like tea", backend="ollama", model="gemma3:1b")
+    base.update(overrides)
+    return ChatRequestEnhanced(**base)
+
+
+@pytest.mark.asyncio
+async def test_stream_injects_memory_block():
+    # Mock stream_completion to return an async generator that yields "Hello"
+    # and capture the messages argument
+    async def mock_stream(*args, **kwargs):
+        mock_stream.messages = args[0]  # first argument is messages
+        yield "Hello"
+
+    mock_stream.messages = None
+
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="About the user:\n- Likes tea")), \
+         patch.object(chat_api, "stream_completion", mock_stream):
+        chunks = [c async for c in chat_api._stream_chat_response(_request(), user_id="u-1")]
+    assert chunks == ["Hello"]
+    # Check that the first argument to stream_completion (the messages list) starts with the memory block
+    sent_messages = mock_stream.messages
+    assert sent_messages[0] == {"role": "system", "content": "About the user:\n- Likes tea"}
+
+
+@pytest.mark.asyncio
+async def test_stream_skips_block_when_empty():
+    # Mock stream_completion to return an async generator that yields "Hi"
+    async def mock_stream(*args, **kwargs):
+        mock_stream.messages = args[0]  # first argument is messages
+        yield "Hi"
+
+    mock_stream.messages = None
+
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="")), \
+         patch.object(chat_api, "stream_completion", mock_stream):
+        # We only need the first chunk to verify the call
+        chunk = [c async for c in chat_api._stream_chat_response(_request(), user_id="u-1")][0]
+    assert chunk == "Hi"
+    # Check that the first argument to stream_completion does not contain a system block for persistent memory
+    sent_messages = mock_stream.messages
+    # If there is a system message, it should not be the persistent memory block
+    if sent_messages[0]["role"] == "system":
+        assert "persistent memory" not in sent_messages[0]["content"]
+    # Otherwise, the first message is not a system message (should be the user message)
+
+
+@pytest.mark.asyncio
+async def test_non_stream_path_triggers_extraction():
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="")), \
+         patch.object(chat_api, "complete_text", new=AsyncMock(return_value="Enjoy your tea!")), \
+         patch.object(chat_api.asyncio, "create_task") as mock_task, \
+         patch.object(chat_api, "run_memory_update", new=AsyncMock()):
+        await chat_api._handle_chat_request(_request(), user_id="u-1")
+    assert mock_task.called
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_request_without_user_skips_memory_load():
+    with patch.object(chat_api, "load_memory_block", new=AsyncMock(return_value="")) as mock_load, \
+         patch.object(chat_api, "complete_text", new=AsyncMock(return_value="ok")):
+        await chat_api._handle_chat_request(_request())
+    mock_load.assert_not_called()

--- a/tests/test_user_memory_wiring.py
+++ b/tests/test_user_memory_wiring.py
@@ -5,13 +5,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import app.backend.api.chat as chat_api
-from app.backend.models.api_models import ChatRequestEnhanced
+from app.backend.models.api_models import ChatRequestEnhanced, RAGQueryRequestEnhanced
 
 
 async def aiter(items):
     """Wrap a plain list as an async iterator (shadows the builtin, which needs an async iterable)."""
     for item in items:
         yield item
+
+
+async def _empty(*_args, **_kwargs):
+    """Async generator yielding nothing (for mocking streaming calls)."""
+    return
+    yield
 
 
 def _request(**overrides):
@@ -55,10 +61,8 @@ async def test_stream_skips_block_when_empty():
     assert chunk == "Hi"
     # Check that the first argument to stream_completion does not contain a system block for persistent memory
     sent_messages = mock_stream.messages
-    # If there is a system message, it should not be the persistent memory block
-    if sent_messages[0]["role"] == "system":
-        assert "persistent memory" not in sent_messages[0]["content"]
-    # Otherwise, the first message is not a system message (should be the user message)
+    system_blocks = [m for m in sent_messages if m["role"] == "system"]
+    assert all("persistent memory" not in m["content"] for m in system_blocks)
 
 
 @pytest.mark.asyncio
@@ -107,6 +111,25 @@ async def test_rag_query_injects_memory_block():
     assert "answer" in chunks
     assert block in sent
     assert sent.index(block) < sent.index({"role": "user", "content": "hi"})
+
+
+@pytest.mark.asyncio
+async def test_standard_rag_skill_forwards_memory_block_to_query():
+    """StandardRAGSkill.stream must pass memory_block into rag_service.query."""
+    from app.skills.rag import StandardRAGSkill
+
+    mock_rag_service = MagicMock()
+    mock_rag_service.query.side_effect = _empty
+
+    request = RAGQueryRequestEnhanced(query="what is x")
+    skill = StandardRAGSkill()
+    chunks = [
+        c
+        async for c in skill.stream(request, mock_rag_service, memory_block="About the user:\n- Likes tea")
+    ]
+
+    assert chunks == []
+    assert mock_rag_service.query.call_args.kwargs["memory_block"] == "About the user:\n- Likes tea"
 
 
 # ── Voice pipeline ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## 📋 Description

Adds per-user persistent memory to LiteMindUI. Important facts a user shares (preferences, projects, corrections) survive across sessions and providers: after each chat/voice exchange an LLM extraction pass turns them into JSON ops, stores them in PostgreSQL, and every chat/RAG/voice request prepends an "About the user" system block so fresh conversations start personalized. Managed automatically plus manually via `/api/memory` CRUD and a new Settings → Memory panel.

Design doc: `docs/superpowers/specs/2026-08-23-user-memory-design.md`

## 🔧 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test changes

## 🚀 What's Changed

- **Store** (`app/backend/user_memory_store.py`): `user_memories` table (FK → users, ON DELETE CASCADE), asyncpg pool singleton, user-scoped CRUD + clear; schema created idempotently in app lifespan (degrades to warning when Postgres unreachable)
- **Service** (`app/services/user_memory_service.py`): memory-block formatting; op parsing (≤3 ops/turn, 500-char cap, malformed/mangled-UUID ops dropped); gateway-backed extraction (15s timeout); per-op isolated application; fire-and-forget `run_memory_update` that never affects responses
- **Injection**: chat (`_build_messages_with_history`), RAG (`rag_service.query` + both skills via additive protocol param; multi-agent CrewAI path unchanged), realtime voice (`apply_memory_to_voice_settings`)
- **API** (`app/backend/api/memory.py`): authenticated CRUD at `/api/memory` incl. clear; content capped 1–500 chars
- **Frontend**: MemorySettings panel in Settings (add/edit/delete/clear) with newest-first list
- **Tests**: pure-fn, wiring, API, and store suites (+36 tests); real-Postgres integration test gated on `TEST_DATABASE_URL`
- **Docs**: CLAUDE.md, AGENTS.md, README.md updated with memory mechanics and user-scoping rule

## 🧪 Testing

- [ ] Tested with Docker Hub images
- [ ] Tested with build from source
- [x] Tested frontend functionality (npm lint + build clean)
- [x] Tested backend API endpoints (pytest: 625 passed)
- [ ] Tested RAG functionality
- [ ] Tested Web Search functionality
- [ ] Tested with Ollama backend
- [ ] Tested with NIM backend
- [ ] Tested with OpenRouter backend

Full suite: `2 failed, 625 passed, 1 skipped` — the 2 failures (`test_auth_router` register TypeErrors) pre-exist on `main`; the skip is the `TEST_DATABASE_URL`-gated integration test. ruff + ty clean.

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)